### PR TITLE
Nonuniform grid plots

### DIFF
--- a/postgkyl/data/data.py
+++ b/postgkyl/data/data.py
@@ -531,6 +531,10 @@ class Data(object):
         return self._grid
     #end
 
+    def getGridType(self):
+        return self._gridType
+    #end
+
     def getValues(self):
         return self._values
     #end

--- a/postgkyl/data/dg.py
+++ b/postgkyl/data/dg.py
@@ -248,6 +248,21 @@ def _makeMesh(nInterp, Xc, xlo=None, xup=None, gridType=None):
     return meshOut
 #end
 
+def _make1Dgrids(nInterp, Xc, numDims, gridType=None):
+  # build a list of 1D arrays, each containing the grid in that dimension.
+  gridOut = list() 
+  if gridType is None or gridType=="uniform":
+    gridOut = [_makeMesh(nInterp, Xc[d])
+               for d in range(numDims)]
+  elif gridType=="mapped":
+    # back out 1D arrays from Xc.
+    for d in range(numDims):
+      currSlices = [0]*numDims
+      currSlices[-1-d] = np.s_[:]
+      gridOut.append(_makeMesh(nInterp, Xc[d][tuple(currSlices)],gridType=gridType))
+    #end
+  #end
+  return gridOut
 
 def _interpOnMesh(cMat, qIn):
     numCells = np.array(qIn.shape)
@@ -390,8 +405,7 @@ class GInterpNodal(GInterp):
                                    axis=-1)
             #end
         #end
-        grid = [_makeMesh(nInterp, self.Xc[d])
-                for d in range(self.numDims)]
+        grid = _make1Dgrids(nInterp, self.Xc, self.numDims)
         if overwrite:
             self.data.push(grid, values)
         else:
@@ -414,8 +428,7 @@ class GInterpNodal(GInterp):
                 values[:,i] *= 2/(self.Xc[i][1]-self.Xc[i][0])
             #end
         #end
-        grid = [_makeMesh(nInterp, self.Xc[d])
-                for d in range(self.numDims)]
+        grid = _make1Dgrids(nInterp, self.Xc, self.numDims)
         if overwrite:
             self.data.push(grid, values)
         else:
@@ -510,16 +523,7 @@ class GInterpModal(GInterp):
                                    axis=-1)
             #end
         #end
-        if self.gridType=="uniform":
-            grid = [_makeMesh(nInterp, self.Xc[d])
-                    for d in range(self.numDims)]
-        elif self.gridType=="mapped":
-            # back out 1D arrays from Xc.
-            grid = list() 
-            for d in range(self.numDims):
-              currSlices = [0]*self.numDims
-              currSlices[-1-d] = np.s_[:]
-              grid.append(_makeMesh(nInterp, self.Xc[d][currSlices],gridType=self.gridType))
+        grid = _make1Dgrids(nInterp, self.Xc, self.numDims, self.gridType)
 
         if overwrite:
             self.data.push(grid, values)
@@ -545,8 +549,7 @@ class GInterpModal(GInterp):
                 values[...,i] *= 2/(self.Xc[i][1]-self.Xc[i][0])
             #end
         #end
-        grid = [_makeMesh(nInterp, self.Xc[d])
-                for d in range(self.numDims)]
+        grid = _make1Dgrids(nInterp, self.Xc, self.numDims, self.gridType)
         if overwrite:
             self.data.push(grid, values)
         else:


### PR DESCRIPTION
Add support for non-uniform grids (i.e. from using NonUniformRectCart in gkyl) in pgkyl data loading and interpolate. Tried 1x1v and 1x2v plots and animations and they look good. Also tried selecting 1D slices in 1x1v and they also look good.

Not adding reviewers for now, but @pcagas said it looked safe to merge.