### PR TITLE
Adding 'copystyle' command

### DIFF
--- a/postgkyl/commands/__init__.py
+++ b/postgkyl/commands/__init__.py
@@ -4,6 +4,7 @@ from . import util
 from . import ev_cmd
 from .animate import animate
 from .collect import collect
+from .copystyle import copystyle
 from .differentiate import differentiate
 from .euler import euler
 from .ev import ev

--- a/postgkyl/commands/copystyle.py
+++ b/postgkyl/commands/copystyle.py
@@ -1,0 +1,25 @@
+import click
+import shutil
+import os.path
+
+from postgkyl.commands.util import vlog, pushChain
+
+@click.command(help='Print info of active datasets.')
+@click.argument('filename')
+@click.pass_context
+def copystyle(ctx, **kwargs):
+  vlog(ctx, 'Starting copystyle')
+  pushChain(ctx, 'copystyle', **kwargs)
+  
+  out_fn = kwargs["filename"]
+  if len(out_fn.split('.')) == 1:
+    out_fn = '{:s}.mplstyle'.format(out_fn)
+  elif out_fn.split('.')[1] != 'mplstyle':
+    out_fn = '{:s}.mplstyle'.format(out_fn)
+  #end
+  pstyle_src = '{:s}/../output/postgkyl.mplstyle'.format(os.path.dirname(os.path.realpath(__file__)))
+
+  shutil.copyfile(pstyle_src, out_fn)
+  
+  vlog(ctx, 'Finishing copystyle')
+#end

--- a/postgkyl/pgkyl.py
+++ b/postgkyl/pgkyl.py
@@ -155,6 +155,7 @@ def cli(ctx, **kwargs):
 cli.add_command(cmd.activate)
 cli.add_command(cmd.animate)
 cli.add_command(cmd.collect)
+cli.add_command(cmd.copystyle)
 cli.add_command(cmd.current)
 cli.add_command(cmd.deactivate)
 cli.add_command(cmd.differentiate)


### PR DESCRIPTION
Adding `copystyle` command which allows you to make a copy of the default Postgkyl Matplotlib style file, modify it, and then use it in the `plot` command using the `--style FILENAME` option