### PR TITLE
Fixing a bux in `plot`

### DIFF
--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -460,7 +460,8 @@ def plot(data, args=(),
     if logy:
       cax.set_yscale('log')
     #end
-    #plt.autoscale(enable=True, axis='x', tight=True)
+    plt.autoscale(enable=True, axis='x', tight=True)
+    plt.autoscale(enable=True, axis='y')
     cax.set_xlim(xmin, xmax)
     cax.set_ylim(ymin, ymax)
 


### PR DESCRIPTION
Scaling now works correctly for multiple datasets