### PR TITLE
Improving contour plot behavior

### DIFF
--- a/postgkyl/commands/plot.py
+++ b/postgkyl/commands/plot.py
@@ -23,7 +23,12 @@ from postgkyl.commands.util import verb_print
 @click.option('-c', '--contour', is_flag=True,
               help="Make contour plot.")
 @click.option('--clevels', type=click.STRING,
-              help="Specify levels for contours: either integer or start:end:nlevels")
+              help="Specify levels for contours: comma-separated or start:end:nlevels")
+@click.option('--cnlevels', type=click.INT,
+              help="Specify the number of levels for contours")
+@click.option('--contlabel', 'cont_label', is_flag=True,
+              help="Add labels to contours")
+
 @click.option('-q', '--quiver', is_flag=True,
               help="Make quiver plot.")
 @click.option('-l', '--streamline', is_flag=True,

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -54,7 +54,7 @@ def plot(data, args=(),
          num_subplot_row=None, num_subplot_col=None,
          streamline=False, sdensity=1, arrowstyle='simple',
          quiver=False,
-         contour=False, clevels=None,
+         contour=False, clevels=None, cnlevels=None, cont_label=False,
          diverging=False,
          lineouts=None, group=None,
          xmin=None, xmax=None, xscale=1.0,
@@ -305,12 +305,14 @@ def plot(data, args=(),
 
       if contour:  #--------------------------------------------------
         levels = 10
-        if clevels:
+        if cnlevels:
+          levels = int(cnlevels)-1
+        elif clevels:
           if ":" in clevels:
             s = clevels.split(":")
             levels = np.linspace(float(s[0]), float(s[1]), int(s[2]))
           else:
-            levels = int(clevels)
+            levels = np.array(clevels.split(','))
           #end
         #end
         cc_grid = _get_cell_centered_grid(grid, cells)
@@ -318,7 +320,10 @@ def plot(data, args=(),
         z = values[..., comp].transpose() * zscale
         im = cax.contour(x, y, z,
                          levels, *args,
-                         colors=cl, linewidths=linewidth)
+                         colors=color, linewidths=linewidth)
+        if cont_label:
+          cax.clabel(im, inline=1)
+        #end
 
 
       elif quiver:  #-------------------------------------------------


### PR DESCRIPTION
1. Fixing the bug where setting the color did not affect contours.
2. Splitting the `clevels` parameter to `clevels` and `cnlevels`. `cnlevels` now specifies an integer number of levels. Note that this behavior is slightly different from the Matplotlib itself where setting `levels` as in integer _N_ automatically picks _N+1_ levels between the minimal and maximum value. `clevels` can be specified as either a comma-separated string or as `start:end:nlevels`. 
3. Adding a new flag `contlabel` to enable contour labels 
`pgkyl rt-two-stream-p2_elc_1.bp interp pl -c --color 'k' --clevels '0.5' --contlabel`
 
![image](https://github.com/ammarhakim/postgkyl/assets/15108613/6d36c38c-f3b0-43f0-98cc-a0934320839d)
 