### PR TITLE
Diagnostic syntax update

### DIFF
--- a/postgkyl/commands/euler.py
+++ b/postgkyl/commands/euler.py
@@ -28,38 +28,34 @@ def euler(ctx, **kwargs):
   v = kwargs['variable_name']
   for dat in data.iterator(kwargs['use']):
     verb_print(ctx, 'euler: Extracting {:s} from data set'.format(v))
-    overwrite = True
+    out = dat
     if kwargs['tag']:
-      overwrite = False
       out = GData(tag=kwargs['tag'],
                   label=kwargs['label'],
                   comp_grid=ctx.obj['compgrid'],
                   meta=dat.meta)
+      data.add(out)
     #end
     if v == "density":
-      grid, values = diag.get_density(dat, overwrite=overwrite)
+      diag.get_density(dat, out_mom=out)
     elif v == "xvel":
-      grid, values = diag.get_vx(dat, overwrite=overwrite)
+      diag.get_vx(dat, out_mom=out)
     elif v == "yvel":
-      grid, values = diag.get_vy(dat, overwrite=overwrite)
+      diag.get_vy(dat, out_mom=out)
     elif v == "zvel":
-      grid, values = diag.get_vz(dat, overwrite=overwrite)
+      diag.get_vz(dat, out_mom=out)
     elif v == "vel":
-      grid, values = diag.get_vi(dat, overwrite=overwrite)
+      diag.get_vi(dat, out_mom=out)
     elif v == "pressure":
-      grid, values = diag.get_p(dat, gasGamma=kwargs['gas_gamma'], numMom=5, overwrite=overwrite)
+      diag.get_p(dat, gas_gamma=kwargs['gas_gamma'], num_moms=5, out_mom=out)
     elif v == "ke":
-      grid, values = diag.get_ke(dat, gasGamma=kwargs['gas_gamma'], numMom=5, overwrite=overwrite)
+      diag.get_ke(dat, gas_gamma=kwargs['gas_gamma'], num_moms=5, out_mom=out)
     elif v == "temp":
-      grid, values = diag.get_temp(dat, gasGamma=kwargs['gas_gamma'], numMom=5, overwrite=overwrite)
+      diag.get_temp(dat, gas_gamma=kwargs['gas_gamma'], num_moms=5, out_mom=out)
     elif v == "sound":
-      grid, values = diag.get_sound(dat, gasGamma=kwargs['gas_gamma'], numMom=5, overwrite=overwrite)
+      diag.get_sound(dat, gas_gamma=kwargs['gas_gamma'], num_moms=5, out_mom=out)
     elif v == "mach":
-      grid, values = diag.get_mach(dat, gasGamma=kwargs['gas_gamma'], numMom=5, overwrite=overwrite)
-    #end
-    if kwargs['tag']:
-      out.push(grid, values)
-      data.add(out)
+      diag.get_mach(dat, gas_gamma=kwargs['gas_gamma'], num_moms=5, out_mom=out)
     #end
   #end
   verb_print(ctx, 'Finishing euler')

--- a/postgkyl/commands/load.py
+++ b/postgkyl/commands/load.py
@@ -55,6 +55,8 @@ def _crush(s): # Temp function used as a sorting key
               help='Specify the file name containing c2p mapped coordinates')
 @click.option('--fv', is_flag=True,
               help='Tag finite volume data when using c2p mapped coordinates')
+@click.option('--source', '-s', type=click.STRING,
+              help='Allows to specify the Adios variable name (default is \'CartGridField\')')
 @click.pass_context
 def load(ctx, **kwargs):
   verb_print(ctx, 'Starting load')
@@ -116,18 +118,19 @@ def load(ctx, **kwargs):
   if len(varNames) == 1:
     varNames = varNames[0].split(',')
   #end
-  
+
   for var in varNames:
     for fn in files:
       try:
-        dat = GData(file_name=fn, tag=kwargs['tag'],
-                    comp_grid=ctx.obj['compgrid'],
-                    z0=z0, z1=z1, z2=z2,
-                    z3=z3, z4=z4, z5=z5,
-                    comp=comp, var_name=var,
+        dat = GData(file_name = fn, tag = kwargs['tag'],
+                    comp_grid = ctx.obj['compgrid'],
+                    z0 = z0, z1 = z1, z2 = z2,
+                    z3 = z3, z4 = z4, z5 = z5,
+                    comp = comp, var_name = var,
                     label = kwargs['label'],
-                    mapc2p_name = mapc2p_name)
-        
+                    mapc2p_name = mapc2p_name,
+                    source = kwargs['source'])
+
         if kwargs['fv']:
           dg = GInterpModal(dat, 0, 'ms')
           dg.interpolateGrid(overwrite=True)

--- a/postgkyl/commands/tenmoment.py
+++ b/postgkyl/commands/tenmoment.py
@@ -13,6 +13,8 @@ from postgkyl.commands.util import verb_print
                                  "zvel", "vel", "pressureTensor",
                                  "pxx", "pxy", "pxz", "pyy", "pyz", "pzz",
                                  "pressure", "temp", "ke", "sound", "mach"]))
+@click.option('-g', '--gas_gamma', help="Gas adiabatic constant",
+              type=click.FLOAT, default=5.0/3.0)
 @click.option('--tag', '-t',
               help='Optional tag for the resulting array')
 @click.option('--label', '-l',
@@ -28,52 +30,48 @@ def tenmoment(ctx, **kwargs):
   v = kwargs['variable_name']
   for dat in data.iterator(kwargs['use']):
     verb_print(ctx, 'tenmoment: Extracting {:s} from data set'.format(v))
-    overwrite = True
+    out = dat
     if kwargs['tag']:
-      overwrite = False
       out = GData(tag=kwargs['tag'],
                   label=kwargs['label'],
                   comp_grid=ctx.obj['compgrid'],
                   meta=dat.meta)
+      data.add(out)
     #end
     if v == "density":
-      grid, values = diag.get_density(dat, overwrite=overwrite)
+      diag.get_density(dat, out_mom=out)
     elif v == "xvel":
-      grid, values = diag.get_vx(dat, overwrite=overwrite)
+      diag.get_vx(dat, out_mom=out)
     elif v == "yvel":
-      grid, values = diag.get_vy(dat, overwrite=overwrite)
+      diag.get_vy(dat, out_mom=out)
     elif v == "zvel":
-      grid, values = diag.get_vz(dat, overwrite=overwrite)
+      diag.get_vz(dat, out_mom=out)
     elif v == "vel":
-      grid, values = diag.get_vi(dat, overwrite=overwrite)
+      diag.get_vi(dat, out_mom=out)
     elif v == "pressureTensor":
-      grid, values = diag.get_pij(dat, overwrite=overwrite)
+      diag.get_pij(dat, out_mom=out)
     elif v == "pxx":
-      grid, values = diag.get_pxx(dat, overwrite=overwrite)
+      diag.get_pxx(dat, out_mom=out)
     elif v == "pxy":
-      grid, values = diag.get_pxy(dat, overwrite=overwrite)
+      diag.get_pxy(dat, out_mom=out)
     elif v == "pxz":
-      grid, values = diag.get_pxz(dat, overwrite=overwrite)
+      diag.get_pxz(dat, out_mom=out)
     elif v == "pyy":
-      grid, values = diag.get_pyy(dat, overwrite=overwrite)
+      diag.get_pyy(dat, out_mom=out)
     elif v == "pyz":
-      grid, values = diag.get_pyz(dat, overwrite=overwrite)
+      diag.get_pyz(dat, out_mom=out)
     elif v == "pzz":
-      grid, values = diag.get_pzz(dat, overwrite=overwrite)
+      diag.get_pzz(dat, out_mom=out)
     elif v == "pressure":
-      grid, values = diag.get_p(dat, numMom=10, overwrite=overwrite)
+      diag.get_p(dat, gas_gamma=kwargs['gas_gamma'], num_moms=10, out_mom=out)
     elif v == "ke":
-      grid, values = diag.get_ke(dat, numMom=10, overwrite=overwrite)
+      diag.get_ke(dat, gas_gamma=kwargs['gas_gamma'], num_moms=10, out_mom=out)
     elif v == "temp":
-      grid, values = diag.get_temp(dat, numMom=10, overwrite=overwrite)
+      diag.get_temp(dat, gas_gamma=kwargs['gas_gamma'], num_moms=10, out_mom=out)
     elif v == "sound":
-      grid, values = diag.get_sound(dat, numMom=10, overwrite=overwrite)
+      diag.get_sound(dat, gas_gamma=kwargs['gas_gamma'], num_moms=10, out_mom=out)
     elif v == "mach":
-      grid, values = diag.get_mach(dat, numMom=10, overwrite=overwrite)
-    #end
-    if kwargs['tag']:
-      out.push(grid, values)
-      data.add(out)
+      diag.get_mach(dat, gas_gamma=kwargs['gas_gamma'], num_moms=10, out_mom=out)
     #end
   #end
   verb_print(ctx, 'Finishing tenmoment')

--- a/postgkyl/data/__init__.py
+++ b/postgkyl/data/__init__.py
@@ -1,5 +1,5 @@
 # import data handler
-from .gdata import GData 
+from .gdata import GData
 # import interpolators
 #from .dg import GInterpZeroOrder
 from .dg import GInterpNodal
@@ -14,3 +14,4 @@ from . import recovData
 
 from .load_gkyl import load_gkyl
 from .load_h5 import load_h5
+from .load_flash import load_flash

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -379,7 +379,7 @@ class GData(object):
       elif extension == 'bp':
         import adios
         self.fileType = 'adios'
-        fh =  adios.file(file_name)
+        fh = adios.file(file_name)
         timeMeshList = [key for key, _ in fh.vars.items() if 'TimeMesh' in key]
         dataList = [key for key, _ in fh.vars.items() if 'Data' in key]
         if len(dataList) > 0:

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -114,8 +114,7 @@ class GData(object):
     self._source = source
   #end
 
-  #-----------------------------------------------------------------
-  #-- File Loading -------------------------------------------------
+  #---- File Loading ---------------------------------------------------
   def _createOffsetCountBp(self, bpVar, zs, comp, grid=None):
     num_dims = len(bpVar.dims)
     count = np.array(bpVar.dims)
@@ -381,8 +380,8 @@ class GData(object):
         import adios
         self.fileType = 'adios'
         fh =  adios.file(file_name)
-        timeMeshList = [key for key, val in fh.vars.items() if 'TimeMesh' in key]
-        dataList = [key for key, val in fh.vars.items() if 'Data' in key]
+        timeMeshList = [key for key, _ in fh.vars.items() if 'TimeMesh' in key]
+        dataList = [key for key, _ in fh.vars.items() if 'Data' in key]
         if len(dataList) > 0:
           for i in range(len(dataList)):
             if i==0:
@@ -442,7 +441,6 @@ class GData(object):
   #end
 
 
-  #---------------------------------------------------------------------
   #---- Stuff Control --------------------------------------------------
   def getTag(self):
     return self._tag
@@ -564,8 +562,8 @@ class GData(object):
     return self
   #end
 
-  #-----------------------------------------------------------------
-  #-- Info ---------------------------------------------------------
+
+  #---- Info -----------------------------------------------------------
   def info(self):
     """Prints Data object information.
 
@@ -653,13 +651,12 @@ class GData(object):
   #end
 
 
-  #-----------------------------------------------------------------
-  #-- Write --------------------------------------------------------
+  #---- Write ----------------------------------------------------------
   def write(self,
-            bufferSize: int = 1000,
             out_name: str = None,
             mode: str = 'bp',
             var_name: str = None,
+            bufferSize: int = 1000,
             append = False,
             cleaning = True):
     """Writes data in ADIOS .bp file, ASCII .txt file, or NumPy .npy file
@@ -728,11 +725,6 @@ class GData(object):
         adios.close(fh)
         adios.finalize()
       else:
-        # fw = adios.writer(out_name, mode='a')
-        # fw.declare_group('CartField', method='POSIX1')
-        # fw.define_var(var_name, sNumCells)
-        # fw[var_name] = self.getValues()
-        # fw.close()
         adios.init_noxml()
         adios.set_max_buffer_size(bufferSize)
         groupId = adios.declare_group('CartField', '')

--- a/postgkyl/data/load_flash.py
+++ b/postgkyl/data/load_flash.py
@@ -1,7 +1,29 @@
 import numpy as np
 import math
 import tables as tbl
-import os.path
+
+# ----------------------------------------------------------------------
+# FLASH variable names
+# dens : the density in g/cc
+# tele : the electron temperature in K
+# tion : same but for the ions
+# velx : the fluid velocity in x direction
+# vely : the fluid velocity in y direction
+# temp : the overall fluid temperature in K
+# pres : the pressure in dyn/cm^2
+# ye
+# sumy
+#
+# The last two variables are used to retrieve the ion and electron
+# density in /cc:
+# n_ele = ye * Na * dens
+# n_ion = sumy * Na * dens
+# where Na=6.02e23 is the Avogadro number.
+#
+# The average ionisation Z' and average atomic mass A' can be found by:
+# Z' = ye/sumy
+# A' = 1/sumy
+# ----------------------------------------------------------------------
 
 def load_flash(file_name : str, var_name : str) -> tuple:
   fh = tbl.open_file(file_name, 'r')
@@ -14,6 +36,8 @@ def load_flash(file_name : str, var_name : str) -> tuple:
   res = bsize.min(axis=1)
   lower = (coord-bsize/2).min(axis=1)
   upper = (coord+bsize/2).max(axis=1)
+  #lower = coord.min(axis=1)
+  #upper = coord.max(axis=1)
 
   nxax = math.floor((upper[0]-lower[0]) / (res[0]/nxb))
   nyax = math.floor((upper[1]-lower[1]) / (res[1]/nyb))

--- a/postgkyl/data/load_flash.py
+++ b/postgkyl/data/load_flash.py
@@ -1,0 +1,36 @@
+import numpy as np
+import math
+import tables as tbl
+import os.path
+
+def load_flash(file_name : str, var_name : str) -> tuple:
+  fh = tbl.open_file(file_name, 'r')
+  coord = fh.root['coordinates'].read().transpose()
+  bsize = fh.root['block size'].read().transpose()
+  ntype = fh.root['node type'].read().transpose()
+  bdata = fh.root[var_name].read().transpose()
+
+  nxb, nyb, _, N = bdata.shape
+  res = bsize.min(axis=1)
+  lower = (coord-bsize/2).min(axis=1)
+  upper = (coord+bsize/2).max(axis=1)
+
+  nxax = math.floor((upper[0]-lower[0]) / (res[0]/nxb))
+  nyax = math.floor((upper[1]-lower[1]) / (res[1]/nyb))
+  data = np.zeros((nxax, nyax))
+  for b in range(N):
+    if ntype[b] == 1:
+      mult = np.ceil(bsize[:,b]/res)
+      idxx = math.floor((coord[0,b] - bsize[0,b]/2 - lower[0]) / res[0] * nxb)
+      idxy = math.floor((coord[1,b] - bsize[1,b]/2 - lower[1]) / res[1] * nyb)
+      for i in range(nxb):
+        for j in range(nyb):
+          data[idxx+i*int(mult[0]):idxx+(i+1)*int(mult[0])+1,
+               idxy+j*int(mult[1]):idxy+(j+1)*int(mult[1])+1] = bdata[i,j,0,b]
+        #end
+      #end
+    #end
+  #end
+  fh.close()
+  return 2, (nxax, nyax), (lower[:2], upper[:2]), data
+#end

--- a/postgkyl/tools/__init__.py
+++ b/postgkyl/tools/__init__.py
@@ -1,3 +1,5 @@
+from .input_parser import _input_parser
+
 from .calculus import integrate
 
 from .fft import fft
@@ -74,8 +76,6 @@ from . import filters
 from .filters import fftData
 from .filters import fftFiltering
 from .filters import butterFiltering
-
-from .input_parser import _input_parser
 
 from .laguerre_compose import laguerre_compose
 from .transform_frame import transform_frame

--- a/postgkyl/tools/prim_vars.py
+++ b/postgkyl/tools/prim_vars.py
@@ -1,215 +1,162 @@
-#!/usr/bin/env python
 """
 Postgkyl module for computing primitive variables from conservative variables
 """
 import numpy as np
-from postgkyl.tools import input_parser
+from typing import Union
 
-def get_density(in_data, overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid = in_grid
+# ---- Postgkyl imports ------------------------------------------------
+from postgkyl.data import GData
+from postgkyl.tools import _input_parser
+# ----------------------------------------------------------------------
+
+
+def get_density(in_mom : Union[GData, tuple],
+                out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = in_values[..., 0, np.newaxis]
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_vx(in_data=None,
-           in_grid=None, in_values=None,
-           overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_vx(in_mom : Union[GData, tuple],
+           out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  out_values = in_values[..., 1, np.newaxis]
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  rhovx = in_values[..., 1, np.newaxis]
-  out_values = rhovx/rho
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_vy(in_data=None,
-           in_grid=None, in_values=None,
-           overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_vy(in_mom : Union[GData, tuple],
+           out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  out_values = in_values[..., 2, np.newaxis]
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  rhovy = in_values[..., 2, np.newaxis]
-  out_values = rhovy/rho
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_vz(in_data=None,
-           in_grid=None, in_values=None,
-           overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_vz(in_mom : Union[GData, tuple],
+           out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  out_values = in_values[..., 3, np.newaxis]
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  rhovz = in_values[..., 3, np.newaxis]
-  out_values = rhovz/rho
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_vi(in_data=None,
-           in_grid=None, in_values=None,
-           overwrite=False):
+def get_vi(in_mom : Union[GData, tuple],
+           out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  out_values = in_values[..., 1:4, np.newaxis]
 
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  rhovi = in_values[..., 1:4, np.newaxis]
-  out_values = rhovi/rho
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pxx(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-
+def get_pxx(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vx = get_vx(in_mom)
   out_values = in_values[..., 4, np.newaxis] - rho*vx*vx
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pxy(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-
+def get_pxy(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vx = get_vx(in_mom)
+  _, vy = get_vy(in_mom)
   out_values = in_values[..., 5, np.newaxis] - rho*vx*vy
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pxz(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-
+def get_pxz(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vx = get_vx(in_mom)
+  _, vz = get_vz(in_mom)
   out_values = in_values[..., 6, np.newaxis] - rho*vx*vz
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pyy(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-
+def get_pyy(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vy = get_vy(in_mom)
   out_values = in_values[..., 7, np.newaxis] - rho*vy*vy
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pyz(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-
+def get_pyz(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vy = get_vy(in_mom)
+  _, vz = get_vz(in_mom)
   out_values = in_values[..., 8, np.newaxis] - rho*vy*vz
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pzz(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-
+def get_pzz(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vz = get_vz(in_mom)
   out_values = in_values[..., 9, np.newaxis] - rho*vz*vz
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_pij(in_data=None,
-            in_grid=None, in_values=None,
-            overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
+def get_pij(in_mom : Union[GData, tuple],
+            out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = np.zeros(in_values[..., 4:10].shape)
 
-  out_grid, pxx = get_pxx(in_data, in_grid, in_values)
-  out_grid, pxy = get_pxy(in_data, in_grid, in_values)
-  out_grid, pxz = get_pxz(in_data, in_grid, in_values)
-  out_grid, pyy = get_pyy(in_data, in_grid, in_values)
-  out_grid, pyz = get_pyz(in_data, in_grid, in_values)
-  out_grid, pzz = get_pzz(in_data, in_grid, in_values)
+  _, pxx = get_pxx(in_mom)
+  _, pxy = get_pxy(in_mom)
+  _, pxz = get_pxz(in_mom)
+  _, pyy = get_pyy(in_mom)
+  _, pyz = get_pyz(in_mom)
+  _, pzz = get_pzz(in_mom)
 
   out_values[..., 0] = np.squeeze(pxx)
   out_values[..., 1] = np.squeeze(pxy)
@@ -218,317 +165,245 @@ def get_pij(in_data=None,
   out_values[..., 4] = np.squeeze(pyz)
   out_values[..., 5] = np.squeeze(pzz)
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_p(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, numMom=None,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  if numMom is None:
-    if in_data.getNumComps() == 5:
-      numMom = 5
-    elif in_data.getNumComps() == 10:
-      numMom = 10
+def get_p(in_mom : Union[GData, tuple],
+          gas_gamma : float = 5.0/3,
+          num_moms : int = None,
+          out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  num_comps = in_values.shape[-1]
+  if num_moms is None:
+    if num_comps == 5:
+      num_moms = 5
+    elif num_comps == 10:
+      num_moms = 10
     else:
       raise ValueError("Number of components appears to be {:d};"
-                       "it needs to be specified using 'numMom' "
-                       "(5 or 10)".format(in_data.getNumComps()))
+                       "it needs to be specified using 'num_moms' "
+                       "(5 or 10)".format(num_comps))
     #end
   #end
 
-  if numMom == 5:
-    out_grid, rho = get_density(in_data, in_grid, in_values)
-    out_grid, vx = get_vx(in_data, in_grid, in_values)
-    out_grid, vy = get_vy(in_data, in_grid, in_values)
-    out_grid, vz = get_vz(in_data, in_grid, in_values)
-
-    out_values = (gasGamma - 1)*(in_values[..., 4, np.newaxis] - 0.5*rho*(vx**2 + vy**2 + vz**2))
-  elif numMom == 10:
-    out_grid, pxx = get_pxx(in_data, in_grid, in_values)
-    out_grid, pyy = get_pyy(in_data, in_grid, in_values)
-    out_grid, pzz = get_pzz(in_data, in_grid, in_values)
-
+  if num_moms == 5:
+    _, rho = get_density(in_mom)
+    _, vx = get_vx(in_mom)
+    _, vy = get_vy(in_mom)
+    _, vz = get_vz(in_mom)
+    out_values = (gas_gamma - 1)*(in_values[..., 4, np.newaxis] - 0.5*rho*(vx**2 + vy**2 + vz**2))
+  elif num_moms == 10:
+    _, pxx = get_pxx(in_mom)
+    _, pyy = get_pyy(in_mom)
+    _, pzz = get_pzz(in_mom)
     out_values = (pxx + pyy + pzz) / 3.0
   #end
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
+#end
 #end
 
-def get_ke(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, numMom=None,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  if numMom is None:
-    if in_data.getNumComps() == 5:
-      numMom = 5
-    elif in_data.getNumComps() == 10:
-      numMom = 10
+def get_ke(in_mom : Union[GData, tuple],
+           gas_gamma : float = 5.0/3,
+           num_moms : int = None,
+           out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  num_comps = in_values.shape[-1]
+  if num_moms is None:
+    if num_comps == 5:
+      num_moms = 5
+    elif num_comps == 10:
+      num_moms = 10
     else:
       raise ValueError("Number of components appears to be {:d};"
-                       "it needs to be specified using 'numMom' "
-                       "(5 or 10)".format(in_data.getNumComps()))
+                       "it needs to be specified using 'num_moms' "
+                       "(5 or 10)".format(num_comps))
     #end
   #end
 
-  if numMom == 5:
-    out_grid, pr = get_p(in_data, in_grid, in_values, gasGamma, numMom)
-
-    out_values = in_values[..., 4, np.newaxis] - pr/(gasGamma - 1)
-  elif numMom == 10:
-    out_grid, rho = get_density(in_data, in_grid, in_values)
-    out_grid, vx = get_vx(in_data, in_grid, in_values)
-    out_grid, vy = get_vy(in_data, in_grid, in_values)
-    out_grid, vz = get_vz(in_data, in_grid, in_values)
-
+  if num_moms == 5:
+    _, pr = get_p(in_mom, gas_gamma=gas_gamma, num_moms=num_moms)
+    out_values = in_values[..., 4, np.newaxis] - pr/(gas_gamma - 1)
+  elif num_moms == 10:
+    _, rho = get_density(in_mom)
+    _, vx = get_vx(in_mom)
+    _, vy = get_vy(in_mom)
+    _, vz = get_vz(in_mom)
     out_values = 0.5*rho*(vx**2 + vy**2 + vz**2)
   #end
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_temp(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, numMom=None,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, pr = get_p(in_data, in_grid, in_values, gasGamma, numMom)
-
+def get_temp(in_mom : Union[GData, tuple],
+             gas_gamma : float = 5.0/3,
+             num_moms : int = None,
+             out_mom : GData = None) -> tuple:
+  grid, rho = get_density(in_mom)
+  _, pr = get_p(in_mom, gas_gamma=gas_gamma, num_moms=num_moms)
   out_values = pr/rho
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_sound(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, numMom=None,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_sound(in_mom : Union[GData, tuple],
+              gas_gamma : float = 5.0/3,
+              num_moms : int = None,
+              out_mom : GData = None) -> tuple:
+  grid, rho = get_density(in_mom)
+  _, pr = get_p(in_mom, gas_gamma=gas_gamma, num_moms=num_moms)
+  out_values = np.sqrt(gas_gamma*pr/rho)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, pr = get_p(in_data, in_grid, in_values, gasGamma, numMom)
-
-  out_values = np.sqrt(gasGamma*pr/rho)
-
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
+#end
 #end
 
-def get_mach(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, numMom=None,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-  out_grid, cs = get_sound(in_data, in_grid, in_values, gasGamma, numMom)
-
+def get_mach(in_mom : Union[GData, tuple],
+             gas_gamma : float = 5.0/3,
+             num_moms : int = None,
+             out_mom : GData = None) -> tuple:
+  grid, vx = get_vx(in_mom)
+  _, vy = get_vy(in_mom)
+  _, vz = get_vz(in_mom)
+  _, cs = get_sound(in_mom, gas_gamma=gas_gamma, num_moms=num_moms)
   out_values = np.sqrt(vx**2+vy**2+vz**2)/cs
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_Bx(in_data=None,
-               in_grid=None, in_values=None,
-               overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid = in_grid
+# ---- MHD -------------------------------------------------------------
+def get_mhd_Bx(in_mom : Union[GData, tuple],
+               out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = in_values[..., 5, np.newaxis]
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_By(in_data=None,
-               in_grid=None, in_values=None,
-               overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid = in_grid
+def get_mhd_By(in_mom : Union[GData, tuple],
+               out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = in_values[..., 6, np.newaxis]
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_Bz(in_data=None,
-               in_grid=None, in_values=None,
-               overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid = in_grid
+def get_mhd_Bz(in_mom : Union[GData, tuple],
+               out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = in_values[..., 7, np.newaxis]
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_Bi(in_data=None,
-           in_grid=None, in_values=None,
-           overwrite=False):
-
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-  out_grid = in_grid
+def get_mhd_Bi(in_mom : Union[GData, tuple],
+               out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
   out_values = in_values[..., 5:8, np.newaxis]
-  if overwrite:
-    in_data.push(out_grid, out_values)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_mag_p(in_data=None,
-          in_grid=None, in_values=None,
-          mu0=1.0,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_mhd_mag_p(in_mom : Union[GData, tuple],
+                  mu_0=1.0,
+                  out_mom : GData = None) -> tuple:
+  grid, Bx = get_mhd_Bx(in_mom)
+  _, By = get_mhd_By(in_mom)
+  _, Bz = get_mhd_Bz(in_mom)
+  out_values = 0.5*(Bx**2 + By**2 + Bz**2)/mu_0
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-
-  out_grid, Bx = get_mhd_Bx(in_data, in_grid, in_values)
-  out_grid, By = get_mhd_By(in_data, in_grid, in_values)
-  out_grid, Bz = get_mhd_Bz(in_data, in_grid, in_values)
-
-  out_values = 0.5*(Bx**2 + By**2 + Bz**2)/mu0
-
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_p(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, mu0=1.0,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_mhd_p(in_mom : Union[GData, tuple],
+              gas_gamma=5.0/3, mu_0=1.0,
+              out_mom : GData = None) -> tuple:
+  grid, in_values = _input_parser(in_mom)
+  _, rho = get_density(in_mom)
+  _, vx = get_vx(in_mom)
+  _, vy = get_vy(in_mom)
+  _, vz = get_vz(in_mom)
+  _, mag_p = get_mhd_mag_p(in_mom, mu_0=mu_0)
+
+  out_values = (gas_gamma - 1)*(in_values[..., 4, np.newaxis] - 0.5*rho*(vx**2 + vy**2 + vz**2) - mag_p)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-  out_grid, mag_p = get_mhd_mag_p(in_data, in_grid, in_values, mu0)
-
-  out_values = (gasGamma - 1)*(in_values[..., 4, np.newaxis] - 0.5*rho*(vx**2 + vy**2 + vz**2) - mag_p)
-
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_temp(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, mu0=1.0,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, pr = get_mhd_p(in_data, in_grid, in_values, gasGamma, mu0)
-
+def get_mhd_temp(in_mom : Union[GData, tuple],
+                 gas_gamma=5.0/3, mu_0=1.0,
+                 out_mom : GData = None) -> tuple:
+  grid, rho = get_density(in_mom)
+  _, pr = get_mhd_p(in_mom, gas_gamma=gas_gamma, mu_0=mu_0)
   out_values = pr/rho
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_sound(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, mu0=1.0,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
+def get_mhd_sound(in_mom : Union[GData, tuple],
+                  gas_gamma=5.0/3, mu_0=1.0,
+                  out_mom : GData = None) -> tuple:
+  grid, rho = get_density(in_mom)
+  _, pr = get_mhd_p(in_mom, gas_gamma=gas_gamma, mu_0=mu_0)
+
+  out_values = np.sqrt(gas_gamma*pr/rho)
+
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-
-  out_grid, rho = get_density(in_data, in_grid, in_values)
-  out_grid, pr = get_mhd_p(in_data, in_grid, in_values, gasGamma, mu0)
-
-  out_values = np.sqrt(gasGamma*pr/rho)
-
-  if overwrite:
-    in_data.push(out_grid, out_values)
-  #end
-  return out_grid, out_values
+  return grid, out_values
 #end
 
-def get_mhd_mach(in_data=None,
-          in_grid=None, in_values=None,
-          gasGamma=5.0/3.0, mu0=1.0,
-          overwrite=False):
-  if in_data:
-    in_grid = in_data.getGrid()
-    in_values = in_data.getValues()
-  #end
-
-  out_grid, vx = get_vx(in_data, in_grid, in_values)
-  out_grid, vy = get_vy(in_data, in_grid, in_values)
-  out_grid, vz = get_vz(in_data, in_grid, in_values)
-  out_grid, cs = get_mhd_sound(in_data, in_grid, in_values, gasGamma, mu0)
-
+def get_mhd_mach(in_mom : Union[GData, tuple],
+                 gas_gamma=5.0/3, mu_0=1.0,
+                 out_mom : GData = None) -> tuple:
+  grid, vx = get_vx(in_mom)
+  _, vy = get_vy(in_mom)
+  _, vz = get_vz(in_mom)
+  _, cs = get_mhd_sound(in_mom, gas_gamma=gas_gamma, mu_0=mu_0)
   out_values = np.sqrt(vx**2+vy**2+vz**2)/cs
 
-  if overwrite:
-    in_data.push(out_grid, out_values)
+  if (out_mom):
+    out_mom.push(grid, out_values)
   #end
-  return out_grid, out_values
+  return grid, out_values
 #end


### PR DESCRIPTION
`prim_vars` functions have been updated with the new syntax introduced with the `laguerre_compose` function. This adds a simple redirection that handles the duality of input (`GData` or `numpy` arrays) much more cleanly.

Functions now take only one input and are agnostic about the type:
```
from postgkyl.tools import _input_parser
...
def get_density(in_mom : Union[GData, tuple],
                out_mom : GData = None) -> tuple:
  grid, in_values = _input_parser(in_mom)
  out_values = in_values[..., 0, np.newaxis]
  ...
```
As a result, the `euler` and `tenmoment` commands have also been simplified. The bug #89 is now also fixed.