### PR TITLE
Updating the PKPM commands to use the new 'vars' output

### DIFF
--- a/postgkyl/commands/gkyl_pkpm.py
+++ b/postgkyl/commands/gkyl_pkpm.py
@@ -27,9 +27,7 @@ def gkylpkpm(ctx, **kwargs):
 
   gf = GData('{:s}-{:s}_{:s}.gkyl'.format(
     kwargs['name'], kwargs['species'], kwargs['idx']))
-  gmoms = GData('{:s}-{:s}_pkpm_moms_{:s}.gkyl'.format(
-    kwargs['name'], kwargs['species'], kwargs['idx']))
-  gu = GData('{:s}-fluid_{:s}_u_{:s}.gkyl'.format(
+  gvars = GData('{:s}-{:s}_pkpm_vars_{:s}.gkyl'.format(
     kwargs['name'], kwargs['species'], kwargs['idx']))
 
   num_dims = gf.getNumDims()
@@ -38,14 +36,12 @@ def gkylpkpm(ctx, **kwargs):
   dg = GInterpModal(gf, kwargs['polyorder'], 'pkpmhyb')
   dg.interpolate((0,1), overwrite=True)
 
-  dg = GInterpModal(gmoms, kwargs['polyorder'], 'ms')
-  dg.interpolate((0,1,2,3,4,5,6), overwrite=True)
+  dg = GInterpModal(gvars, kwargs['polyorder'], 'ms')
+  grid_and_T_m = dg.interpolate(3)
+  grid_and_us = dg.interpolate((0,1,2))
 
-  dg = GInterpModal(gu, kwargs['polyorder'], 'ms')
-  dg.interpolate((0,1,2), overwrite=True)
-
-  laguerre_compose(gf, gmoms, gf)
-  transform_frame(gf, gu, c_dim, gf)
+  laguerre_compose(gf, grid_and_T_m, gf)
+  transform_frame(gf, grid_and_us, c_dim, gf)
 
   gf.setTag(kwargs['tag'])
   gf.setLabel(kwargs['label'])

--- a/postgkyl/commands/laguerre_compose.py
+++ b/postgkyl/commands/laguerre_compose.py
@@ -8,9 +8,9 @@ from postgkyl.tools import laguerre_compose
 
 @click.command(help='Compose PKPM Laguerre coefficients together.')
 @click.option('--distribution', '-f', type=click.STRING, prompt=True,
-              help='Specify the PKPM distribution function.')
-@click.option('--moments', '-m', type=click.STRING, prompt=True,
-              help='Specify the PKPM moments.')
+              help='Specify the PKPM distribution function dataset.')
+@click.option('--tm', type=click.STRING, prompt=True,
+              help='Specify the PKPM vars dataset.')
 @click.option('--tag', '-t',
               help='Optional tag for the resulting array')
 @click.option('--label', '-l',
@@ -20,16 +20,16 @@ def laguerrecompose(ctx, **kwargs):
   verb_print(ctx, 'Starting laguerrecompose')
   data = ctx.obj['data']
 
-  for f, mom in zip(data.iterator(kwargs['distribution']),
-                    data.iterator(kwargs['moments'])):
+  for f, tm in zip(data.iterator(kwargs['distribution']),
+                    data.iterator(kwargs['tm'])):
     if kwargs['tag']:
       out = GData(tag=kwargs['tag'],
                   label=kwargs['label'],
                   comp_grid=ctx.obj['compgrid'],
                   meta=f.meta)
-      laguerre_compose(f, mom, out)
+      laguerre_compose(f, tm, out)
     else:
-      laguerre_compose(f, mom, f)
+      laguerre_compose(f, tm, f)
     #end
   #end
   verb_print(ctx, 'Finishing laguerrecompose')

--- a/postgkyl/tools/laguerre_compose.py
+++ b/postgkyl/tools/laguerre_compose.py
@@ -7,7 +7,7 @@ from postgkyl.tools import _input_parser
 # ----------------------------------------------------------------------
 
 def laguerre_compose(in_f : Union[GData, tuple],
-                     in_mom : Union[GData, tuple],
+                     in_T_m : Union[GData, tuple],
                      out_f : GData = None) -> tuple:
   """Compose PKPM expansion coefficients into a single f.
 
@@ -17,7 +17,7 @@ def laguerre_compose(in_f : Union[GData, tuple],
 
   Args:
     in_f: 2-component Laguerre expansion coefficients.
-    in_mom: PKPM moments to calculate T over m.
+    in_T_m: PKPM T over m.
     out_f: (Optional) GData to store output.
 
   Returns:
@@ -25,7 +25,7 @@ def laguerre_compose(in_f : Union[GData, tuple],
     dimension) and a numpy array with values.
   """
   in_f_grid, in_f_values = _input_parser(in_f)
-  _, in_mom_values = _input_parser(in_mom)
+  _, in_T_m_values = _input_parser(in_T_m)
 
   x, vpar = in_f_grid[0], in_f_grid[1]
   vperp = np.copy(vpar)
@@ -36,12 +36,9 @@ def laguerre_compose(in_f : Union[GData, tuple],
 
   _, _, vperp_3D = np.meshgrid(x_cc, vpar_cc, vperp_cc, indexing='ij')
 
-  rho = in_mom_values[..., 0]
-  p_perp = in_mom_values[..., 2]
-  T_m = p_perp/rho
-
   F0 = in_f_values[..., 0]
   G = in_f_values[..., 1]
+  T_m = in_T_m_values[..., 0]
 
   F1 = F0 - (G.transpose()/T_m).transpose()
 


### PR DESCRIPTION
PKPM commands and diagnostics have been updated to use the new `pkpm_vars` output.