### PR TITLE
Using adios2 python binding for reading adios data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,6 @@ dependencies:
   - matplotlib
   - click
   - conda-forge::adios2=2.9.1
-  - conda-forge::adios=1.13.1
-  - conda-forge::adios-python=1.13.1=py38h522c649_1006
   - pytables
   - scipy
   - sympy

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
   - numpy=1.21.*
   - matplotlib
   - click
+  - conda-forge::adios2=2.9.1
   - conda-forge::adios=1.13.1
   - conda-forge::adios-python=1.13.1=py38h522c649_1006
   - pytables

--- a/meta.yaml
+++ b/meta.yaml
@@ -32,8 +32,6 @@ requirements:
     - click
     - sympy
     - conda-forge::adios2=2.9.1
-    - conda-forge::adios=1.13.1
-    - conda-forge::adios-python=1.13.1=py38h522c649_1006
     - adios
     - adios-python
     - msgpack-python

--- a/meta.yaml
+++ b/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - pytables
     - click
     - sympy
+    - conda-forge::adios2=2.9.1
     - conda-forge::adios=1.13.1
     - conda-forge::adios-python=1.13.1=py38h522c649_1006
     - adios

--- a/meta.yaml
+++ b/meta.yaml
@@ -32,8 +32,6 @@ requirements:
     - click
     - sympy
     - conda-forge::adios2=2.9.1
-    - adios
-    - adios-python
     - msgpack-python
 
 test:

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -174,7 +174,7 @@ class GData(object):
 
   def getInputFile(self):
     import adios2
-    fh = adios2.open(self.file_name, 'r')
+    fh = adios2.open(self.file_name, 'rra')
     inputFile = fh.read_attribute_string('inputfile')[0]
     fh.close()
     return inputFile

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -381,6 +381,9 @@ class GData(object):
       var_name = self._var_name
     #end
 
+    values = np.empty_like(self.getValues())
+    values[...] = self.getValues()
+
     if mode == 'bp':
 
       import adios2
@@ -397,14 +400,14 @@ class GData(object):
           fh.write('time', self.ctx['time'])
         #end
 
-        fh.write(var_name, self.getValues(), full_shape, offset, full_shape)
+        fh.write(var_name, values, full_shape, offset, full_shape)
 
         fh.close()
 
       else:
 
         fh = adios2.open(out_name, "a")
-        fh.write(var_name, self.getValues(), full_shape, offset, full_shape)
+        fh.write(var_name, values, full_shape, offset, full_shape)
         fh.close()
 
       #end
@@ -415,7 +418,6 @@ class GData(object):
       for d in range(num_dims):
         grid[d] = 0.5*(grid[d][1:]+grid[d][:-1])
       #end
-      values = self.getValues()
 
       basis = np.full(num_dims, 1.0)
       for d in range(num_dims-1):
@@ -442,7 +444,6 @@ class GData(object):
       #end
       fh.close()
     elif mode == 'npy':
-      values = self.getValues()
       np.save(out_name, values.squeeze())
     #end
   #end

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -389,7 +389,7 @@ class GData(object):
       import adios2
       if not append:
 
-        fh = adios2.open(out_name, "w")
+        fh = adios2.open(out_name, "w", engine_type="BP3")
 
         lo, up = self.getBounds()
         fh.write_attribute('numCells', numCells)
@@ -406,7 +406,7 @@ class GData(object):
 
       else:
 
-        fh = adios2.open(out_name, "a")
+        fh = adios2.open(out_name, "a", engine_type="BP3")
         fh.write(var_name, values, full_shape, offset, full_shape)
         fh.close()
 

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -82,6 +82,7 @@ class GData(object):
     self.ctx['polyOrder'] = None
     self.ctx['basisType'] = None
     self.ctx['isModal'] = None
+    self.ctx['grid_type'] = 'uniform'
     if ctx:
       for key in ctx:
         self.ctx[key] = ctx[key]

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -173,9 +173,9 @@ class GData(object):
   #end
 
   def getInputFile(self):
-    import adios
-    fh = adios.file(self.file_name)
-    inputFile = adios.attr(fh, 'inputfile').value.decode('UTF-8')
+    import adios2
+    fh = adios2.open(self.file_name, 'r')
+    inputFile = fh.read_attribute_string('inputfile')[0]
     fh.close()
     return inputFile
   #end

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -137,7 +137,9 @@ class Read_gkyl_adios(object):
                         upper[d],
                         cells[d]+1)
             for d in range(num_dims)]
-    offset, count = self._create_offset_count(cells, self.axes, self.comp, grid)
+    var_dims = fh.available_variables()[self.var_name]['Shape']
+    var_dims = [int(v) for v in var_dims.split(',')]
+    offset, count = self._create_offset_count(var_dims, self.axes, self.comp, grid)
     data = fh.read(self.var_name, start=offset, count=count)
 
     # Adjust boundaries for 'offset' and 'count'

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -110,7 +110,7 @@ class Read_gkyl_adios(object):
       self.ctx['builddate'] = fh.read_attribute_string('builddate')[0]
     #end
     if 'polyOrder' in fh.available_attributes().keys():
-      self.ctx['polyOrder'] = fh.read_attribute('polyOrder')
+      self.ctx['polyOrder'] = fh.read_attribute('polyOrder')[0]
       self.ctx['isModal'] = True
     #end
     if 'basisType' in fh.available_attributes().keys():
@@ -118,17 +118,17 @@ class Read_gkyl_adios(object):
       self.ctx['isModal'] = True
     #end
     if 'charge' in fh.available_attributes().keys():
-      self.ctx['charge'] = fh.read_attribute('charge')
+      self.ctx['charge'] = fh.read_attribute('charge')[0]
     #end
     if 'mass' in fh.available_attributes().keys():
-      self.ctx['mass'] = fh.read_attribute('mass')
+      self.ctx['mass'] = fh.read_attribute('mass')[0]
     #end
     if 'time' in fh.available_variables():
       self.ctx['time'] = fh.read('time')
     #end
     if 'frame' in fh.available_variables():
       self.ctx['frame'] = fh.read('frame')
-     #end
+    #end
 
 
     # Load data

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -34,7 +34,7 @@ class Read_gkyl_adios(object):
     # imported when actially needed
     try:
       import adios2
-      fh = adios2.open(self.file_name, "r")
+      fh = adios2.open(self.file_name, "rra")
       for key in fh.available_variables():
         if 'TimeMesh' in key:
           self.is_diagnostic = True
@@ -96,7 +96,7 @@ class Read_gkyl_adios(object):
 
   def _read_frame(self) -> tuple:
     import adios2
-    fh = adios2.open(self.file_name, "r")
+    fh = adios2.open(self.file_name, "rra")
 
     # Postgkyl conventions require the attributes to be
     # narrays even for 1D data

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -139,7 +139,8 @@ class Read_gkyl_adios(object):
             for d in range(num_dims)]
     var_dims = fh.available_variables()[self.var_name]['Shape']
     var_dims = [int(v) for v in var_dims.split(',')]
-    offset, count = self._create_offset_count(var_dims, self.axes, self.comp, grid)
+    offset, count = self._create_offset_count(
+            var_dims, self.axes, self.comp, grid)
     data = fh.read(self.var_name, start=offset, count=count)
 
     # Adjust boundaries for 'offset' and 'count'
@@ -175,10 +176,11 @@ class Read_gkyl_adios(object):
     #  self.ctx['grid_type'] = adios.attr(fh, 'type').value.decode('UTF-8')
     #end
     if self.c2p:
-      grid_fh = adios.file(self.c2p)
-      grid_var = adios.var(grid_fh, 'CartGridField')
-      offset, count = self._create_offset_count(grid_var, self.axes, None)
-      tmp = grid_var.read(offset=offset, count=count)
+      grid_fh = adios2.open(self.c2p, 'r')
+      grid_dims = grid_fh.available_variables()['CartGridField']['Shape']
+      grid_dims = [int(v) for v in grid_dims.split(',')]
+      offset, count = self._create_offset_count(grid_dims, self.axes, None)
+      tmp = grid_fh.read('CartGridField', start=offset, count=count)
       num_comps = tmp.shape[-1]
       num_coeff = num_comps/num_dims
       grid = [tmp[..., int(d*num_coeff):int((d+1)*num_coeff)]

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -146,7 +146,7 @@ class Read_gkyl_adios(object):
     # Adjust boundaries for 'offset' and 'count'
     dz = (upper - lower) / cells
     if offset:
-      if self.ctx['grid_type']== 'uniform':
+      if self.ctx['grid_type'] == 'uniform':
         lower = lower + offset[:num_dims]*dz
         cells = cells - offset[:num_dims]
       elif self.ctx['grid_type'] == 'mapped':
@@ -158,10 +158,10 @@ class Read_gkyl_adios(object):
       #end
     #end
     if count:
-      if self._gridType == 'uniform':
+      if self.ctx['grid_type']  == 'uniform':
         upper = lower + count[:num_dims]*dz
         cells = count[:num_dims]
-      elif self._gridType == 'mapped':
+      elif self.ctx['grid_type']  == 'mapped':
         idx = np.full(num_dims, 0)
         for d in range(num_dims):
           idx[-d-1] = count[d]-1  #.Reverse indexing of idx because of transpose() in composing self._grid.

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -220,18 +220,18 @@ class Read_gkyl_adios(object):
     return grid, lower, upper, data
 
   def _read_diagnostic(self) -> tuple:
-    import adios
-    fh = adios.file(self.file_name)
+    import adios2
+    fh = adios2.open(self.file_name, "r")
 
-    time_lst = [key for key, _ in fh.vars.items() if 'TimeMesh' in key]
-    data_lst = [key for key, _ in fh.vars.items() if 'Data' in key]
+    time_lst = [key for key in fh.available_variables() if 'TimeMesh' in key]
+    data_lst = [key for key in fh.available_variables() if 'Data' in key]
     for i in range(len(data_lst)):
       if i==0:
-        data = np.atleast_1d(adios.var(fh, data_lst[i]).read())
-        grid = np.atleast_1d(adios.var(fh, time_lst[i]).read())
+        data = np.atleast_1d(fh.read(data_lst[i]))
+        grid = np.atleast_1d(fh.read(time_lst[i]))
       else:
-        next_data = np.atleast_1d(adios.var(fh, data_lst[i]).read())
-        next_grid = np.atleast_1d(adios.var(fh, time_lst[i]).read())
+        next_data = np.atleast_1d(fh.read(data_lst[i]))
+        next_grid = np.atleast_1d(fh.read(time_lst[i]))
         # deal with weird behavior after restart where some data
         # doesn't have second dimension
         if len(next_data.shape) < 2:

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os.path
+import re
 
 from postgkyl.utils import idxParser
 
@@ -223,8 +224,16 @@ class Read_gkyl_adios(object):
     import adios2
     fh = adios2.open(self.file_name, "r")
 
+    def natural_sort(l):
+        convert = lambda text: int(text) if text.isdigit() else text.lower()
+        alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
+        return sorted(l, key=alphanum_key)
+
     time_lst = [key for key in fh.available_variables() if 'TimeMesh' in key]
     data_lst = [key for key in fh.available_variables() if 'Data' in key]
+    time_lst = natural_sort(time_lst)
+    data_lst = natural_sort(data_lst)
+
     for i in range(len(data_lst)):
       if i==0:
         data = np.atleast_1d(fh.read(data_lst[i]))

--- a/unit/test_GData.py
+++ b/unit/test_GData.py
@@ -126,24 +126,25 @@ class TestGData(unittest.TestCase):
 
         nc = data.getNumCells()
         assert(isinstance(nc, np.ndarray))
-        assert(isinstance(nc[0], np.int64))
-        assert(isinstance(nc[1], np.int64))
+        assert(isinstance(nc[0], np.int32))
+        assert(isinstance(nc[1], np.int32))
         self.assertEqual(nc[0], 64)
         self.assertEqual(nc[1], 32)
 
-        grid = data.peakGrid()
+        grid = data._grid
         assert(isinstance(grid, list))
         self.assertEqual(len(grid), 2)
         assert(isinstance(grid[0], np.ndarray))
         assert(isinstance(grid[1], np.ndarray))
-        self.assertEqual(grid[0].shape, (64,))
-        self.assertEqual(grid[1].shape, (32,))
+        self.assertEqual(grid[0].shape, (65,))
+        self.assertEqual(grid[1].shape, (33,))
 
-        values = data.peakValues()
+        values = data._values
         assert(isinstance(values, np.ndarray))
         self.assertEqual(values.shape, (64, 32, 8))
 
-        remove('data/frame_0_mod.bp')
+        import shutil
+        shutil.rmtree('data/frame_0_mod.bp')
 
     # def test_WriteTxt(self):
     #     pass


### PR DESCRIPTION
Motivation:
1. Avoid numpy errors due to unmaintained adios v1 python code
2. Stay with the newer, maintained upstream code
3. Allow possible switch to adios2 I/O in Gkyl in the future

Tests:
- Tested with Python 3.11 and adios2 2.9.1 (from [conda-forge](https://anaconda.org/conda-forge/adios2))
  - I created a new conda env to make the dependency resolution easier
- Tested on gkyl g2 fluid moment FV data, and `fieldEnergy` data;
- NOT tested for DG data or c2p.

Other notes:
- Commented-out codes were not adapted

Updates:
- [x] the `nstep=1` feature tested with @pcagas case
  - `pgkyl test.bp -d default_9 pl`
- [x] partial loading with `pgkyl Regression/mom-gem-challenge/rt-10m-gem_field_0.bp sel --z0 1:32 pl`
- [x] 2d DG data from `rt-weibel-2x2v-p1.lua`
- [x] `c2p` test using `pgkyl ls2-lapd-3x2v-p1_elc_gridDiagnostics_0.bp -d Temp --c2p ls2-lapd-3x2v-p1_mapc2p.bp interp -b ms sel --z2 10 pl -a`
- [x] `write` feature updated the corresponding unit test `test_WriteBp` 
- [x] `write` feature tested with `pgkyl ls2-lapd-3x2v-p1_elc_gridDiagnostics_0.bp -d Temp --c2p ls2-lapd-3x2v-p1_mapc2p.bp interp -b ms sel --z2 10 write -f test.bp`
  - the result can be plotted with `pgkyl test.bp -d Temp pl` normally
- [x] `write` feature tested on restart file of `Regression/mom-gem-challenge/rt-5m-gem.lua`; the written restart file seems to be readable by gkyl
  - run `rt-5m-gem.lua` as normal
  - `mv rt-5m-gem_elc_restart.bp rt-5m-gem_elc_restart.old.bp`
  - `pgkyl rt-5m-gem_elc_restart.old.bp write -f rt-5m-gem_elc_restart.bp`
  - modify `tEnd` and `nFrame` in `rt-5m-gem.lua` 
  - restart the simulation using the new restart file written by postgkyl