### PR TITLE
More minor fix for the adios2

### DIFF
--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -94,6 +94,9 @@ class GData(object):
     file_name = str(file_name)
     self.file_name = file_name
     self.mapc2p_name = mapc2p_name
+    self.color = None
+
+    self._status = True
 
     zs = (z0, z1, z2, z3, z4, z5)
 
@@ -112,7 +115,11 @@ class GData(object):
           var_name=var_name,
           c2p=mapc2p_name,
           axes=zs, comp=comp)
-        reader_set = True
+        if self._reader._is_compatible():
+          reader_set = True
+        else:
+          raise TypeError('{:s} cannot be read with the specified {:s} reader.'.format(self.file_name, reader_name))
+        #end
       else:
         for key in self._readers:
           self._reader = self._readers[key](
@@ -128,14 +135,11 @@ class GData(object):
         #end
       #end
       if not reader_set:
-        raise TypeError('\'file_name\' was specified ({:s}) but \'reader\' was either not set or successfully detected'.format(self.file_name))
+        raise TypeError('"file_name" was specified ({:s}) but "reader" was either not set or successfully detected'.format(self.file_name))
       #end
     #end
 
     self._grid, self._values = self._reader.get_data()
-
-    self.color = None
-    self._status = True
   #end
 
 

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -91,6 +91,7 @@ class GData(object):
     self._label = ''
     self._customLabel = label
     self._var_name = var_name
+    file_name = str(file_name)
     self.file_name = file_name
     self.mapc2p_name = mapc2p_name
 

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -35,13 +35,11 @@ class Read_gkyl_adios(object):
     try:
       import adios2
       fh = adios2.open(self.file_name, "rra")
+      if self.var_name in fh.available_variables():
+        self.is_frame = True
       for key in fh.available_variables():
         if 'TimeMesh' in key:
           self.is_diagnostic = True
-          break
-        #end
-        if self.var_name in key:
-          self.is_frame = True
           break
         #end
       #end

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -23,6 +23,7 @@ class Read_gkyl_adios(object):
     self.axes = axes
     self.comp = comp
 
+    self.checked_compatibility = False
     self.is_frame = False
     self.is_diagnostic = False
 
@@ -47,6 +48,7 @@ class Read_gkyl_adios(object):
     except:
       return False
     #end
+    self.checked_compatibility = True
     return self.is_frame or self.is_diagnostic
   #end
 
@@ -260,7 +262,10 @@ class Read_gkyl_adios(object):
 
   # ---- Exposed function ----------------------------------------------
   def get_data(self) -> tuple:
-    grid = None
+    if not self.checked_compatibility:
+      self._is_compatible()
+
+    grid, data = None, None
 
     if self.is_frame:
       grid, lower, upper, data = self._read_frame()

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -38,7 +38,7 @@ class Read_gkyl_adios(object):
       if self.var_name in fh.available_variables():
         self.is_frame = True
       for key in fh.available_variables():
-        if 'TimeMesh' in key:
+        if re.findall(r'TimeMesh\d+', key):
           self.is_diagnostic = True
           break
         #end

--- a/postgkyl/data/read_gkyl_adios.py
+++ b/postgkyl/data/read_gkyl_adios.py
@@ -23,7 +23,6 @@ class Read_gkyl_adios(object):
     self.axes = axes
     self.comp = comp
 
-    self.checked_compatibility = False
     self.is_frame = False
     self.is_diagnostic = False
 
@@ -48,7 +47,6 @@ class Read_gkyl_adios(object):
     except:
       return False
     #end
-    self.checked_compatibility = True
     return self.is_frame or self.is_diagnostic
   #end
 
@@ -262,9 +260,6 @@ class Read_gkyl_adios(object):
 
   # ---- Exposed function ----------------------------------------------
   def get_data(self) -> tuple:
-    if not self.checked_compatibility:
-      self._is_compatible()
-
     grid, data = None, None
 
     if self.is_frame:
@@ -272,7 +267,6 @@ class Read_gkyl_adios(object):
     #end
     if self.is_diagnostic:
       grid, lower, upper, data = self._read_diagnostic()
-      cells = grid[0].shape
     #end
 
     return grid, data


### PR DESCRIPTION
- fix the `var_name` check that sets the `is_frame` flag
- other minor changes to make the code more robust; see the commits

These are perhaps not needed usually in the command line mode, but I got an error when I explicitly specify the `reader_name` to `adios` in the script mode since the relevant flags (`is_frame` etc. are not set).

I believe other readers might have this problem (i.e., when the reader name is explicitly specified, some flags might not be set when used in the reading function).