### PR TITLE
Bug fixes to readers and animate

### DIFF
--- a/postgkyl/commands/animate.py
+++ b/postgkyl/commands/animate.py
@@ -186,7 +186,7 @@ def animate(ctx, **kwargs):
       num_dims = dat.getNumDims()
       if num_dims == 1:
         val = dat.getValues()*kwargs['yscale']
-      elif num_dims == 2:
+      else:
         val = dat.getValues()*kwargs['zscale']
       #end
       if vmin > np.nanmin(val):
@@ -203,7 +203,7 @@ def animate(ctx, **kwargs):
       if kwargs['ymax'] is None:
         kwargs['ymax'] = vmax
       #end
-    elif num_dims == 2:
+    else:
       if kwargs['zmin'] is None:
         kwargs['zmin'] = vmin
       #end

--- a/postgkyl/data/gdata.py
+++ b/postgkyl/data/gdata.py
@@ -28,7 +28,7 @@ class GData(object):
   """
 
   def __init__(self,
-               file_name: str = None,
+               file_name: str = '',
                comp: Union[int, str] = None,
                z0: Union[int, str] = None,
                z1: Union[int, str] = None,
@@ -107,8 +107,7 @@ class GData(object):
       'h5' : Read_gkyl_h5,
       'flash' : Read_flash_h5
       }
-
-    if file_name is not None:
+    if self.file_name != '':
       reader_set = False
       if reader_name in self._readers:
         self._reader = self._readers[reader_name](


### PR DESCRIPTION
Fixing one recent bug that was introduced by adding `str()` to a file name. This was fixed by properly checking if it was defined.

Second was a bug to animate where the automatic range selection did not work for N>2 with `select`.