### PR TITLE
Fixing contour colorbars and adding periodic val2coord

### DIFF
--- a/postgkyl/commands/plot.py
+++ b/postgkyl/commands/plot.py
@@ -229,7 +229,6 @@ def plot(ctx, **kwargs):
     gplot(dat, kwargs['arg'], label_prefix=label, **kwargs)
     # ------------------------------------------------------------------
 
-
     if kwargs['subplots']:
       kwargs['start_axes'] = kwargs['start_axes'] + dat.getNumComps()
     #end

--- a/postgkyl/commands/val2coord.py
+++ b/postgkyl/commands/val2coord.py
@@ -49,6 +49,8 @@ def _getRange(strIn, length):
               help="Select components that will became the grid of the new dataset.")
 @click.option('-y', type=click.STRING,
               help="Select components that will became the values of the new dataset.")
+@click.option('--periodic', '-p', is_flag=True,
+              help="Set the last component to match the first one")
 @click.pass_context
 def val2coord(ctx, **kwargs):
   """Given a dataset (typically a DynVector) selects columns from it to
@@ -92,7 +94,14 @@ def val2coord(ctx, **kwargs):
       #end
 
       x = values[..., xc]
-      y = values[..., yc, np.newaxis]
+      y = values[..., yc]
+
+      if kwargs['periodic']:
+        x = np.append(x, np.atleast_1d(x[0]), axis=0)
+        y = np.append(y, np.atleast_1d(y[0]), axis=0)
+      #end
+
+      y = y[..., np.newaxis] # Adding the required component index
 
       out = GData(tag=outTag,
                   label=kwargs['label'],

--- a/postgkyl/output/__init__.py
+++ b/postgkyl/output/__init__.py
@@ -1,2 +1,3 @@
 # info
 from .plot import plot
+from .plot import _colorbar

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -17,10 +17,7 @@ if sys.version_info[0] >= 3:
 def _colorbar(obj, fig, cax, label="", extend=None):
   divider = make_axes_locatable(cax)
   cax2 = divider.append_axes("right", size="3%", pad=0.05)
-  #if extend:
   return fig.colorbar(obj, cax=cax2, label=label or "", extend=extend)
-  #end
-  #return fig.colorbar(obj, cax=cax2, label=label or "")
 #end
 
 def _get_nodal_grid(grid, cells):
@@ -333,6 +330,7 @@ def plot(data, args=(),
         z = (values[..., comp].transpose() + zshift) * zscale
         im = cax.contour(x, y, z,
                          levels, *args,
+                         origin="lower",
                          colors=color, linewidths=linewidth)
         if cont_label:
           cax.clabel(im, inline=1)
@@ -461,7 +459,6 @@ def plot(data, args=(),
                        format(num_dims))
     #end
 
-
     #---- Additional Formatting ----------------------------------------
     cax.grid(showgrid)
     # Legend
@@ -491,13 +488,16 @@ def plot(data, args=(),
     if logy:
       cax.set_yscale('log')
     #end
-    plt.autoscale(enable=True, axis='x', tight=True)
-    plt.autoscale(enable=True, axis='y')
+    if num_dims == 1: # this causes troubles with contours
+      plt.autoscale(enable=True, axis='x', tight=True)
+      plt.autoscale(enable=True, axis='y')
+    #end
     if xmin is not None or xmax is not None:
       cax.set_xlim(xmin, xmax)
+    #end
     if ymin is not None or ymax is not None:
       cax.set_ylim(ymin, ymax)
-
+    #end
     if num_dims == 2:
       if fixaspect:
         plt.setp(cax, aspect=aspect)

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -498,10 +498,8 @@ def plot(data, args=(),
     if ymin is not None or ymax is not None:
       cax.set_ylim(ymin, ymax)
     #end
-    if num_dims == 2:
-      if fixaspect:
-        plt.setp(cax, aspect=aspect)
-      #end
+    if fixaspect:
+      plt.setp(cax, aspect=aspect)
     #end
   #end
 


### PR DESCRIPTION
A bug was fixed in the Postgkyl plot which caused the contour colorbar not to show properly. This also led to cryptic warning messages.

Additionally, I added a a small option to `vals2coord` which adds a copy of the first value to the end. This is useful for example for plotting a separatrix. 