### PR TITLE
Increasing robustness of contour `clevels`

### DIFF
--- a/postgkyl/commands/plot.py
+++ b/postgkyl/commands/plot.py
@@ -23,7 +23,7 @@ from postgkyl.commands.util import verb_print
 @click.option('-c', '--contour', is_flag=True,
               help="Make contour plot.")
 @click.option('--clevels', type=click.STRING,
-              help="Specify levels for contours: comma-separated or start:end:nlevels")
+              help="Specify levels for contours: comma-separated level values or start:end:nlevels")
 @click.option('--cnlevels', type=click.INT,
               help="Specify the number of levels for contours")
 @click.option('--contlabel', 'cont_label', is_flag=True,

--- a/postgkyl/commands/plot.py
+++ b/postgkyl/commands/plot.py
@@ -92,6 +92,8 @@ from postgkyl.commands.util import verb_print
               help="Set limits for the y-coordinate (lower,upper).")
 @click.option('--zlim', default=None, type=click.STRING,
               help="Set limits for the z-coordinate (lower,upper).")
+@click.option('--relax', is_flag=True,
+              help="Relax the stringent x axis limits for 1D plots.")
 @click.option('--globalrange', '-r', is_flag=True,
               help="Make uniform extends across datasets.")
 @click.option('--legend/--no-legend', default=True,

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -330,7 +330,6 @@ def plot(data, args=(),
         if type(levels) == np.ndarray and len(levels) == 1:
           colorbar = False
         #end
-        print(levels)
         nodal_grid = _get_nodal_grid(grid, cells)
         x = (nodal_grid[0] + xshift) * xscale
         y = (nodal_grid[1] + yshift) * yscale

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -323,8 +323,14 @@ def plot(data, args=(),
             levels = np.linspace(float(s[0]), float(s[1]), int(s[2]))
           else:
             levels = np.array(clevels.split(','))
+            # Filter out empty elements
+            levels = np.array(list(filter(None, levels)))
           #end
         #end
+        if type(levels) == np.ndarray and len(levels) == 1:
+          colorbar = False
+        #end
+        print(levels)
         nodal_grid = _get_nodal_grid(grid, cells)
         x = (nodal_grid[0] + xshift) * xscale
         y = (nodal_grid[1] + yshift) * yscale

--- a/postgkyl/output/plot.py
+++ b/postgkyl/output/plot.py
@@ -66,6 +66,7 @@ def plot(data, args=(),
          xmin=None, xmax=None, xscale=1.0, xshift=0.0,
          ymin=None, ymax=None, yscale=1.0, yshift=0.0,
          zmin=None, zmax=None, zscale=1.0, zshift=0.0,
+         relax=False,
          style=None, rcParams=None,
          legend=True, label_prefix='', colorbar=True,
          xlabel=None, ylabel=None, clabel=None, title=None,
@@ -488,7 +489,7 @@ def plot(data, args=(),
     if logy:
       cax.set_yscale('log')
     #end
-    if num_dims == 1: # this causes troubles with contours
+    if num_dims == 1 and not relax: # this causes troubles with contours
       plt.autoscale(enable=True, axis='x', tight=True)
       plt.autoscale(enable=True, axis='y')
     #end


### PR DESCRIPTION
Adding a filter to the `clevels` option to remove empty entries after the `split`, i.e., inputs like `--cleves '0.5,0.6,'` now works. The empty string was causing issues previously.

Secondly, the colorbar is now disabled when only one value is specified.

This fixes the issue #110.