### PR TITLE
Fixing possibly incorrect limitation on the user defined number of interpolation points

### DIFF
--- a/src/postgkyl/data/dg.py
+++ b/src/postgkyl/data/dg.py
@@ -396,6 +396,7 @@ class GInterpModal(GInterp):
   def __init__(self, data, poly_order=None, basis_type=None,
                numInterp=None, periodic=False, read=None):
     self.numDims = data.get_num_dims()
+    print(numInterp)
     if poly_order is not None:
       self.poly_order = poly_order
     elif data.ctx['poly_order'] is not None:
@@ -430,7 +431,12 @@ class GInterpModal(GInterp):
     #end
 
     self.periodic = periodic
-    if numInterp is not None and self.poly_order > 1:
+
+    # XXX This was introduced with the c2p but I can't see the importance of the extra
+    # condition and seem to unecessarily limit the capabilities. The c2p test cases
+    # still seems to produce correct results. -- P.C.
+    # if numInterp is not None and self.poly_order > 1:
+    if numInterp:
       self.numInterp = numInterp
     else:
       self.numInterp = self.poly_order + 1

--- a/src/postgkyl/data/dg.py
+++ b/src/postgkyl/data/dg.py
@@ -396,7 +396,6 @@ class GInterpModal(GInterp):
   def __init__(self, data, poly_order=None, basis_type=None,
                numInterp=None, periodic=False, read=None):
     self.numDims = data.get_num_dims()
-    print(numInterp)
     if poly_order is not None:
       self.poly_order = poly_order
     elif data.ctx['poly_order'] is not None:

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -22,6 +22,20 @@ class TestGkylInterpolate:
     assert np.array_equal(values.shape, (192, 96, 1))
   #end
 
+  def test_ser_p1_i(self):
+    data = pg.GData('{:s}/test_data/shock-f-ser-p1.gkyl'.format(self.dir_path))
+    dg = pg.GInterpModal(data, poly_order=1, basis_type='ms', numInterp=3)
+    grid, values = dg.interpolate()
+    assert np.array_equal(values.shape, (24, 24, 1))
+  #end
+
+  def test_ser_p2_i(self):
+    data = pg.GData('{:s}/test_data/twostream-f-p2.gkyl'.format(self.dir_path))
+    dg = pg.GInterpModal(data, numInterp=4)
+    grid, values = dg.interpolate()
+    assert np.array_equal(values.shape, (256, 128, 1))
+  #end
+
   def test_ten_p1(self):
     data = pg.GData('{:s}/test_data/shock-f-ten-p1.gkyl'.format(self.dir_path))
     dg = pg.GInterpModal(data, poly_order=1, basis_type='mt')


### PR DESCRIPTION
I introduced the bug (#138) for p=1 during the work on the c2p mapped data but there shouldn't be any reason for it. All tests are passing. In addition, tests including `numInterp` were added to catch this in the future.

Closes #138