### PR TITLE
Fixing quotes in f-strings

### DIFF
--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -16,10 +16,10 @@ def _update(i, data, fig, offsets, kwargs):
     kwargs["title"] = ""
     if not kwargs["notitle"]:
       if dat.ctx["frame"] is not None:
-        kwargs["title"] = f"{kwargs["title"]:s} frame: {dat.ctx["frame"]:d} "
+        kwargs["title"] = f"{kwargs['title']:s} frame: {dat.ctx['frame']:d} "
       # end
       if dat.ctx["time"] is not None:
-        kwargs["title"] = f"{kwargs["title"]:s} time: {dat.ctx["time"]:.4e}"
+        kwargs["title"] = f"{kwargs['title']:s} time: {dat.ctx['time']:.4e}"
       # end
     # end
     if kwargs["arg"] is not None:
@@ -222,7 +222,7 @@ def animate(ctx, **kwargs):
       else:
         for i in range(int(np.nanmin((min_size, len(data_lst))))):
           _update(i, data_lst, figs[-1], offsets, kwargs)
-          plt.savefig(f"{kwargs["saveframes"]:s}_{i:d}.png", dpi=kwargs["dpi"])
+          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
         # end
         kwargs["show"] = False  # do not show in this case
       # end
@@ -251,7 +251,7 @@ def animate(ctx, **kwargs):
     else:
       for i in range(int(np.nanmin((min_size, len(data_lst))))):
         _update(i, data_lst, figs[-1], offsets, kwargs)
-        plt.savefig(f"{kwargs["saveframes"]:s}_{i:d}.png", dpi=kwargs["dpi"])
+        plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
       # end
       kwargs["show"] = False  # do not show in this case
     # end

--- a/src/postgkyl/commands/gkyl_pkpm.py
+++ b/src/postgkyl/commands/gkyl_pkpm.py
@@ -19,8 +19,8 @@ def pkpm(ctx, **kwargs):
   verb_print(ctx, "Starting Gkyl PKPM")
   data = ctx.obj["data"]
 
-  gf = GData(f"{kwargs["name"],:s}-{kwargs["species"]:s}_{kwargs["idx"]:s}.gkyl")
-  gvars = GData(f"{kwargs["name"]:s}-{kwargs["species"]:s}_pkpm_vars_{kwargs["idx"]:s}.gkyl")
+  gf = GData(f"{kwargs['name'],:s}-{kwargs['species']:s}_{kwargs['idx']:s}.gkyl")
+  gvars = GData(f"{kwargs['name']:s}-{kwargs['species']:s}_pkpm_vars_{kwargs['idx']:s}.gkyl")
 
   num_dims = gf.get_num_dims()
   c_dim = num_dims - 1

--- a/src/postgkyl/commands/info.py
+++ b/src/postgkyl/commands/info.py
@@ -26,7 +26,7 @@ def info(ctx, **kwargs):
       bold = False
     # end
     click.echo(
-        click.style(f"{dat.get_label():s}{" " if dat.get_label() else "":s}({dat.get_tag():s}#{i:d})",
+        click.style(f"{dat.get_label():s}{' ' if dat.get_label() else '':s}({dat.get_tag():s}#{i:d})",
             fg=color, bold=bold)
     )
     if not kwargs["compact"]:

--- a/src/postgkyl/commands/plot.py
+++ b/src/postgkyl/commands/plot.py
@@ -219,7 +219,7 @@ def plot(ctx, **kwargs):
     # end
 
     if kwargs["saveframes"]:
-      file_name = f"{kwargs["saveframes"]:s}_{i:d}.png"
+      file_name = f"{kwargs['saveframes']:s}_{i:d}.png"
       plt.savefig(file_name, dpi=kwargs["dpi"])
       kwargs["show"] = False
     # end

--- a/src/postgkyl/commands/style.py
+++ b/src/postgkyl/commands/style.py
@@ -28,7 +28,7 @@ def style(ctx, **kwargs):
 
   if kwargs["print"]:
     for key in ctx.obj["rcParams"]:
-      print(f"{key:s} : {ctx.obj["rcParams"][key]}")
+      print(f"{key:s} : {ctx.obj['rcParams'][key]}")
     # end
   # end
 

--- a/src/postgkyl/commands/temp.py
+++ b/src/postgkyl/commands/temp.py
@@ -10,7 +10,7 @@ from postgkyl.utils import verb_print
 @click.argument("factor", nargs=1, type=click.FLOAT)
 @click.pass_context
 def mult(ctx, **kwargs):
-  verb_print(ctx, f"Multiplying by {kwargs["factor"]:f}")
+  verb_print(ctx, f"Multiplying by {kwargs['factor']:f}")
   for s in ctx.obj["sets"]:
     values = ctx.obj["dataSets"][s].get_values()
     values = values * kwargs["factor"]
@@ -22,7 +22,7 @@ def mult(ctx, **kwargs):
 @click.argument("power", nargs=1, type=click.FLOAT)
 @click.pass_context
 def pow(ctx, **kwargs):
-  verb_print(ctx, f"Calculating the power of {kwargs["power"]:f}")
+  verb_print(ctx, f"Calculating the power of {kwargs['power']:f}")
   for s in ctx.obj["sets"]:
     values = ctx.obj["dataSets"][s].get_values()
     values = values ** kwargs["power"]

--- a/src/postgkyl/data/gdata.py
+++ b/src/postgkyl/data/gdata.py
@@ -332,10 +332,10 @@ class GData(object):
     output = ""
 
     if self.ctx["time"] is not None:
-      output += f"├─ Time: {self.ctx["time"]:e}\n"
+      output += f"├─ Time: {self.ctx['time']:e}\n"
     # end
     if self.ctx["frame"] is not None:
-      output += f"├─ Frame: {self.ctx["frame"]:d}\n"
+      output += f"├─ Frame: {self.ctx['frame']:d}\n"
     # end
     output += f"├─ Number of components: {num_comps:d}\n"
     output += f"├─ Number of dimensions: {num_dims:d}\n"
@@ -366,17 +366,17 @@ class GData(object):
     # end
     if self.ctx["poly_order"] and self.ctx["basis_type"]:
       output += "\n├─ DG info:\n"
-      output += f"│  ├─ Polynomial Order: {self.ctx["poly_order"]:d}\n"
+      output += f"│  ├─ Polynomial Order: {self.ctx['poly_order']:d}\n"
       if self.ctx["is_modal"]:
-        output += f"│  └─ Basis Type: {self.ctx["basis_type"]:s} (modal)"
+        output += f"│  └─ Basis Type: {self.ctx['basis_type']:s} (modal)"
       else:
-        output += f"│  └─ Basis Type: {self.ctx["basis_type"]:s}"
+        output += f"│  └─ Basis Type: {self.ctx['basis_type']:s}"
       # end
     # end
     if self.ctx["changeset"] and self.ctx["builddate"]:
       output += "\n├─ Created with Gkeyll:\n"
-      output += f"│  ├─ Changeset: {self.ctx["changeset"]:s}\n"
-      output += f"│  └─ Build Date: {self.ctx["builddate"]:s}"
+      output += f"│  ├─ Changeset: {self.ctx['changeset']:s}\n"
+      output += f"│  └─ Build Date: {self.ctx['builddate']:s}"
     # end
     for key, val in self.ctx.items():
       if key not in ["time", "frame", "changeset", "builddate", "basis_type",
@@ -422,7 +422,7 @@ class GData(object):
     if not out_name:
       if self._file_name is not None:
         fn = self._file_name
-        out_name = f"{fn.split(".", maxsplit=1)[0].strip("_")}_mod.{extension}"
+        out_name = f"{fn.split('.', maxsplit=1)[0].strip('_')}_mod.{extension}"
       else:
         out_name = f"gdata.{extension}"
       # end

--- a/src/postgkyl/data/gkyl_adios_reader.py
+++ b/src/postgkyl/data/gkyl_adios_reader.py
@@ -178,7 +178,7 @@ class GkylAdiosReader(object):
       if self.click_mode:
         var_name = self.var_name
         while True:
-          var_name = click.prompt(f"Variable name '{var_name:s}' is not available, please select from the available ones: {self.ctx["var_names"]:s}")
+          var_name = click.prompt(f"Variable name '{var_name:s}' is not available, please select from the available ones: {self.ctx['var_names']:s}")
           if var_name in fh.available_variables():
             self.var_name = var_name
             self.ctx.pop("var_names", None)
@@ -187,7 +187,7 @@ class GkylAdiosReader(object):
         # end
       else:
         raise ValueError(
-            f"Could not find the variable '{var_name:s}'; available variables are: {self.ctx["var_names"]:s}"
+            f"Could not find the variable '{var_name:s}'; available variables are: {self.ctx['var_names']:s}"
         )
       # end
     # end

--- a/src/postgkyl/pgkyl.py
+++ b/src/postgkyl/pgkyl.py
@@ -50,7 +50,7 @@ class PgkylCommandGroup(click.Group):
     if matches and len(matches) == 1:
       return click.Group.get_command(self, ctx, matches[0])
     elif matches:
-      ctx.fail(f"Too many matches for '{cmd_name}': {", ".join(sorted(matches))}")
+      ctx.fail(f"Too many matches for '{cmd_name}': {', '.join(sorted(matches))}")
     # end
 
     # cmd_name is a data set


### PR DESCRIPTION
In Python 3.12, the quotes in f-strings are evaluated differently; i.e., quotes for dictionary keys can be the same as those of the string itself.

Fixing to work in Python 3.11.