### PR TITLE
Testing

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -53,9 +53,10 @@ class TestCommands:
   def test_load(self):
     self.ctx.invoke(cmd.load)
     data = self.ctx.obj['data'].get_dataset(0)
-    np.testing.assert_array_equal(data.num_cells, (64, 32))
+    num_cells = data.num_cells
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_array_equal(num_cells, (64, 32))
 
 
   def test_ev_gkyl(self):
@@ -64,18 +65,18 @@ class TestCommands:
     self.ctx.invoke(cmd.ev, chain='f[0] f[0] +')
     data = self.ctx.obj['data'].get_dataset(0)
     values = data.get_values()
-    np.testing.assert_approx_equal(np.max(values), 3.352029)
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_approx_equal(np.max(values), 3.352029)
 
     # Check longer chain, substraction, and not using dataset id
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.ev, chain='f f + f -')
     data = self.ctx.obj['data'].get_dataset(0)
     values = data.get_values()
-    np.testing.assert_approx_equal(np.max(values), 1.676014)
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_approx_equal(np.max(values), 1.676014)
 
     # Check tags
     self.ctx.invoke(cmd.load, tag='ts0')
@@ -83,9 +84,9 @@ class TestCommands:
     self.ctx.invoke(cmd.ev, chain='ts0 ts0 +')
     data = self.ctx.obj['data'].get_dataset(0, tag='ts0')
     values = data.get_values()
-    np.testing.assert_approx_equal(np.max(values), 3.3520293)
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_approx_equal(np.max(values), 3.3520293)
 
     # Check ev functionality on multiple dataset together
     self.ctx.invoke(cmd.load)
@@ -93,12 +94,12 @@ class TestCommands:
     self.ctx.invoke(cmd.ev, chain='f[:] 2 *')
     data0 = self.ctx.obj['data'].get_dataset(0)
     values0 = data0.get_values()
-    np.testing.assert_approx_equal(np.max(values0), 3.3520293)
     data1 = self.ctx.obj['data'].get_dataset(1)
-    values1 = data1.get_values()
-    np.testing.assert_approx_equal(np.max(values1), 3.3520293)
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    values1 = data1.get_values()
+    np.testing.assert_approx_equal(np.max(values0), 3.3520293)
+    np.testing.assert_approx_equal(np.max(values1), 3.3520293)
 
 
   @pytest.mark.skipif(adios_missing, reason="ADIOS2 is not installed")
@@ -106,42 +107,47 @@ class TestCommands:
     # Check metadata
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.load)
-    self.ctx.invoke(cmd.ev, chain='f[1] f[1].charge *')
-    data = self.ctx.obj['data'].get_dataset(0)
+    self.ctx.invoke(cmd.load)
+    self.ctx.invoke(cmd.ev, chain='f[2] f[2].charge *')
+    data = self.ctx.obj['data'].get_dataset(2)
     values = data.get_values()
-    np.testing.assert_approx_equal(np.min(values), -1.676014)
-    # Check if metadata is properly passed through ev:
-    np.testing.assert_approx_equal(data.ctx["charge"], -1.0)
+    charge = data.ctx["charge"]
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_approx_equal(np.min(values), -1.676014)
+    # Check if metadata is properly passed through ev:
+    np.testing.assert_approx_equal(charge, -1.0)
 
 
   def test_interpolate(self):
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.interpolate)
     data = self.ctx.obj['data'].get_dataset(0)
-    np.testing.assert_array_equal(data.num_cells, (192, 96))
+    num_cells = data.num_cells
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_array_equal(num_cells, (192, 96))
 
 
   def test_select(self):
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.select, z0='0:10', z1='0.0', comp='0,3')
     data = self.ctx.obj['data'].get_dataset(0)
-    np.testing.assert_array_equal(data.values.shape, (10, 1, 2))
+    values_shape = data.values.shape
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    np.testing.assert_array_equal(values_shape, (10, 1, 2))
 
 
   def test_plot(self):
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.plot, show=False)
     fig = plt.gcf()
-    assert fig.axes[0].get_ylabel() == "$z_1$"
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
+    label = fig.axes[0].get_ylabel()
     plt.close("all")
+    assert label == "$z_1$"
 
 
   @pytest.mark.skipif(ffmpeg_missing, reason="ffmpeg is not installed")
@@ -151,8 +157,9 @@ class TestCommands:
     fn = tmp_path / "test_anim.mp4"
     self.ctx.invoke(cmd.animate, show=False, saveas=fn)
     fig = plt.gcf()
-    assert fig.get_axes()[0].get_ylabel() == "$z_1$"
-    assert fn.exists()
+    label = fig.get_axes()[0].get_ylabel()
     self.ctx.obj['data'].clean()
     self.ctx.obj["in_data_strings_loaded"] = 0
     plt.close("all")
+    assert label == "$z_1$"
+    assert fn.exists()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,8 @@
 """Postgkyl module for testing data loading."""
-import os
+import importlib
 import numpy as np
+import os
+import pytest
 
 import postgkyl as pg
 
@@ -42,18 +44,25 @@ class TestAdios:
   """Test Gkeyll's ADIOS2 output format."""
   dir_path =  f"{os.path.dirname(__file__)}/test_data"
 
+  adios_loader = importlib.util.find_spec('adios2')
+  adios_missing = adios_loader is None
+
+  @pytest.mark.skipif(adios_missing, reason="ADIOS2 is not installed")
   def test_adios_frame(self):
     data = pg.GData(f"{self.dir_path:s}/twostream-f-p2_0.bp")
     np.testing.assert_array_equal(data.num_cells, (64, 32))
 
+  @pytest.mark.skipif(adios_missing, reason="ADIOS2 is not installed")
   def test_adios_frame(self):
     data = pg.GData(f"{self.dir_path:s}/twostream-f-p1.bp")
     np.testing.assert_array_equal(data.num_cells, (64, 32))
 
+  @pytest.mark.skipif(adios_missing, reason="ADIOS2 is not installed")
   def test_adios_frame_partial(self):
     data = pg.GData(f"{self.dir_path:s}/twostream-f-p2_0.bp", z0=32, comp=0)
     np.testing.assert_array_equal(data.values.shape, (1, 32, 1))
 
+  @pytest.mark.skipif(adios_missing, reason="ADIOS2 is not installed")
   def test_adios_dynvector(self):
     data = pg.GData(f"{self.dir_path:s}/twostream-field-energy.bp")
     np.testing.assert_array_equal(data.num_cells, (15714,))


### PR DESCRIPTION
When Adios is not installed, the Adios tests are correctly skipped instead of failing; the same is true for FFmpeg.