### PR TITLE
Select bug

### DIFF
--- a/src/postgkyl/data/select.py
+++ b/src/postgkyl/data/select.py
@@ -41,12 +41,12 @@ def select(data: GData, comp: int | str | None = None,
   # Loop for coordinates
   for d, z in enumerate(zs):
     if d < num_dims and z is not None:
-      dat_range = bounds[1][d] - bounds[0][d]
-      if '.' in z:
-        if bounds[1][d] + 0.25 * dat_range < float(z) or bounds[0][d] - 0.25 * dat_range > float(z):
-          raise TypeError("The coordinate select is outside of the data boundaries")
-        #end
-      #end
+      #dat_range = bounds[1][d] - bounds[0][d]
+      #if '.' in z:
+      #  if bounds[1][d] + 0.25 * dat_range < float(z) or bounds[0][d] - 0.25 * dat_range > float(z):
+      #    raise TypeError("The coordinate select is outside of the data boundaries")
+      #  #end
+      ##end
       if uniform_grid:
         len_grid = grid[d].shape[0]
       else:

--- a/src/postgkyl/data/select.py
+++ b/src/postgkyl/data/select.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
 
 
 def select(data: GData, comp: int | str | None = None,
-      z0: int | str | None = None, z1: int | str | None = None,
-      z2: int | str | None = None, z3: int | str | None = None,
-      z4: int | str | None = None, z5: int | str | None = None,
+      z0: int | float | str | None = None, z1: int | float | str | None = None,
+      z2: int | float | str | None = None, z3: int | float | str | None = None,
+      z4: int | float | str | None = None, z5: int | float | str | None = None,
       overwrite: bool = False) -> Tuple[list, np.ndarray]:
   """Selects parts of the GData.
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,6 @@
 """Postgkyl module for testing click commands."""
 import click
-import importlib
+import importlib.util
 import matplotlib.pyplot as plt
 import numpy as np
 import os
@@ -14,7 +14,7 @@ class TestCommands:
   """Base class for testing Postgkyl commands.
 
   Note that commands which just wrap other Postgkyl functions are not tested thoroughly,
-  the goal here is to test if the command runs; more thorough testing should be
+  the goal here is to test if the command runs at all; more thorough testing should be
   delegated to the functions themselves.
   """
   dir_path = f"{os.path.dirname(__file__)}/test_data"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,5 +1,4 @@
 """Postgkyl module for testing data loading."""
-import importlib
 import importlib.util
 import numpy as np
 import os
@@ -50,7 +49,6 @@ class TestGkyl:
     dg.interpolate(overwrite=True)
     np.testing.assert_approx_equal(data.bounds[0][1], -1.060964e07)
     np.testing.assert_approx_equal(data.bounds[1][2], 1.206345e-16)
-
 class TestAdios:
   """Test Gkeyll's ADIOS2 output format."""
   dir_path =  f"{os.path.dirname(__file__)}/test_data"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,22 @@
+"""Postgkyl module for testing data loading."""
+import numpy as np
+import os
+
+import postgkyl as pg
+
+
+class TestSelect:
+  """Test Gkeyll's select commands."""
+  dir_path = f"{os.path.dirname(__file__)}/test_data"
+
+  def test_integer(self):
+    data = pg.GData(f"{self.dir_path:s}/shock-f-ser-p1.gkyl")
+    grid, data = pg.data.select(data, z0=1, z1="5:8")
+    np.testing.assert_array_equal(grid[0], [1.375, 1.75 ])
+    np.testing.assert_array_almost_equal(grid[1], [3.926991, 4.712389, 5.497787, 6.283185])
+    np.testing.assert_array_equal(data.shape, (1, 3, 4))
+
+  def test_float(self):
+    data = pg.GData(f"{self.dir_path:s}/shock-f-ser-p1.gkyl")
+    grid, data = pg.data.select(data, z0=0.5)
+    np.testing.assert_array_equal(grid[0], [1.0, 1.375])


### PR DESCRIPTION
PR #147 introduced bounds for `select` arguments. The implementation itself has a minor bug; it does not account for all possible argument types. However, even after a discussion with several developers, it is not clear why the bounds were introduced in the first place, and we are removing them, at least temporarily. 

In addition, simple `select` unit tests have been added to avoid this in the future.