### PR TITLE
Add the ability to specify the labels in the legend 

### DIFF
--- a/src/postgkyl/commands/plot.py
+++ b/src/postgkyl/commands/plot.py
@@ -71,7 +71,7 @@ import postgkyl.output.plot
 @click.option("--cutoffglobalrange", "-cogr", default=None, type=click.FLOAT,
               help="Set custom limit for uniform across datasets")
 @click.option("--legend", default=None, type=click.STRING,
-    help="If specified, comma-separated legend labels (e.g., 'a,b,c'). Use '--no-legend' to hide legend.")
+    help="If specified, comma-separated legend labels (e.g., 'a,b,c').")
 @click.option("--no-legend", is_flag=True, help="Hide legend.")
 @click.option("--force-legend", "forcelegend", is_flag=True,
     help="Force legend even when plotting a single dataset.")


### PR DESCRIPTION
Sometimes, it is nice to specify the legend in our plots. I added the ability to go --legend "a,b,c" to specify the legend in the plot command. It is possible to do this with tagging the data, but this is a different way to do the same thing with cleaner syntax. The default is to use the same lables as before.

Example

` pgkyl gk_leaky_bag_1x2v_p1-ion_integrated_moms.gkyl gk_leaky_bag_1x2v_p1_nux_center-ion_integrated_moms.gkyl pl --legend "UX,NUX" -f0 `
<img width="1246" height="924" alt="image" src="https://github.com/user-attachments/assets/4c15671e-2856-45db-9eee-8af133aa1184" />

`pgkyl gk_leaky_bag_1x2v_p1-ion_integrated_moms.gkyl gk_leaky_bag_1x2v_p1_nux_center-ion_integrated_moms.gkyl pl -f0 `
<img width="1468" height="1084" alt="image" src="https://github.com/user-attachments/assets/b2314091-63ec-49df-88c0-1d0555069e0c" />
