### PR TITLE
Parallel animate

### DIFF
--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -40,15 +40,22 @@ def _save_frames(data_list, num_frames, prefix, kwargs, figsize, fig=None):
 # end
 
 
-def _compile_movie(frame_files, output_file, duration):
-  """Compile a list of PNG frame files into an animated GIF (or other PIL-supported format)."""
-  images = [Image.open(f) for f in frame_files]
-  print(f"Creating movie {output_file}...")
-  images[0].save(
-      output_file, save_all=True, append_images=images[1:],
-      duration=duration, loop=0, optimize=False,
-  )
-  print(f"Movie {output_file} created.")
+def _compile_movie(frame_files, output_file, fps, duration):
+  """Compile PNG frames into an animation."""
+  ext = os.path.splitext(output_file)[1].lower()
+  fps_val = fps if fps else 10
+  print(f"Creating {output_file}...")
+  if ext in (".gif", ".webp", ".apng"):
+    images = [Image.open(f) for f in frame_files]
+    images[0].save(
+        output_file, save_all=True, append_images=images[1:],
+        duration=duration, loop=0, optimize=False,
+    )
+  else:
+    # We do not support other format like .mp4 or .avi.
+    raise ValueError(f"Unsupported output format: {ext}")
+    
+  print(f"{output_file} created.")
 # end
 
 
@@ -204,7 +211,7 @@ def globalrange(data,kwargs):
 @click.option("--notitle", is_flag=True, help="Do not show title.")
 @click.option("-i", "--interval", default=100, help="Specify the animation interval.")
 @click.option("--save", is_flag=True, help="Save figure as PNG.")
-@click.option("--saveas", type=click.STRING, default=None, help="Name to save the plot as.")
+@click.option("--saveas", type=click.STRING, default=None, help="Name to save the plot as. Use .gif please.")
 @click.option("--fps", type=click.INT, help="Specify frames per second for saving.")
 @click.option("--dpi", type=click.INT, help="DPI (resolution) for output.")
 @click.option("-e", "--edgecolors", type=click.STRING, help="Set color for cell edges.")
@@ -230,6 +237,10 @@ def animate(ctx, **kwargs):
   """
   verb_print(ctx, "Starting animate")
   data = ctx.obj["data"]
+
+  if kwargs["saveas"] and not kwargs["saveas"].lower().endswith(".gif"):
+    raise click.ClickException("Currently only .gif output is supported for animations; please specify a .gif file with --saveas.")
+  # end
 
   if kwargs["xlim"]:
     kwargs["xmin"] = float(kwargs["xlim"].split(",")[0])
@@ -325,7 +336,7 @@ def animate(ctx, **kwargs):
         _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
         if kwargs["save"] or kwargs["saveas"]:
           frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
-          _compile_movie(frame_files, file_name, duration)
+          _compile_movie(frame_files, file_name, kwargs["fps"], duration)
         # end
         kwargs["show"] = False
       elif kwargs["nproc"] > 1:
@@ -334,7 +345,7 @@ def animate(ctx, **kwargs):
           tmp_prefix = os.path.join(tmpdir, "frame")
           _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
           frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
-          _compile_movie(frame_files, file_name, duration)
+          _compile_movie(frame_files, file_name, kwargs["fps"], duration)
         # end
         kwargs["show"] = False
       else:
@@ -375,7 +386,7 @@ def animate(ctx, **kwargs):
       _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
       if kwargs["save"] or kwargs["saveas"]:
         frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
-        _compile_movie(frame_files, file_name, duration)
+        _compile_movie(frame_files, file_name, kwargs["fps"], duration)
       # end
       kwargs["show"] = False
     elif kwargs["nproc"] > 1:
@@ -383,7 +394,7 @@ def animate(ctx, **kwargs):
         tmp_prefix = os.path.join(tmpdir, "frame")
         _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
         frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
-        _compile_movie(frame_files, file_name, duration)
+        _compile_movie(frame_files, file_name, kwargs["fps"], duration)
       # end
       kwargs["show"] = False
     else:
@@ -417,7 +428,7 @@ def animate(ctx, **kwargs):
       _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
       if kwargs["save"] or kwargs["saveas"]:
         frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
-        _compile_movie(frame_files, file_name, duration)
+        _compile_movie(frame_files, file_name, kwargs["fps"], duration)
       # end
       kwargs["show"] = False
     elif kwargs["nproc"] > 1:
@@ -425,7 +436,7 @@ def animate(ctx, **kwargs):
         tmp_prefix = os.path.join(tmpdir, "frame")
         _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
         frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
-        _compile_movie(frame_files, file_name, duration)
+        _compile_movie(frame_files, file_name, kwargs["fps"], duration)
       # end
       kwargs["show"] = False
     else:

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -1,10 +1,23 @@
 from matplotlib.animation import FuncAnimation
+from multiprocessing import Pool
 import click
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
 from postgkyl.utils import verb_print, set_frame
 import postgkyl.output.plot
+
+
+def _save_frame_worker(args):
+  """Worker for parallel frame saving; each process creates its own figure."""
+  matplotlib.use("Agg")
+  frame_idx, frame_data, kwargs, saveframes, dpi, figsize = args
+  fig = plt.figure(figsize=figsize)
+  _update(0, [frame_data], fig, kwargs)
+  plt.savefig(f"{saveframes:s}_{frame_idx:d}.png", dpi=dpi)
+  plt.close(fig)
+# end
 
 
 def _update(frame, data, fig, kwargs):
@@ -170,6 +183,8 @@ def globalrange(data,kwargs):
 @click.option("--show/--no-show", default=True, help="Turn showing of the plot ON and OFF.")
 @click.option("--saveframes", type=click.STRING,
     help="Save individual frames as PNGS instead of an animation")
+@click.option("--nproc", default=1, type=click.INT, show_default=True,
+    help="Number of parallel processes for saving frames (requires --saveframes).")
 @click.option("--figsize", help="Comma-separated values for x and y size.")
 @click.option("-m", "--multiblock", is_flag=True, help="Plots blocks from each frame together")
 @click.pass_context
@@ -283,9 +298,18 @@ def animate(ctx, **kwargs):
           anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
         # end
       else:
-        for i in range(int(np.nanmin((min_size, len(data_list))))):
-          _update(i, data_list, figs[-1], kwargs)
-          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+        num_frames = int(np.nanmin((min_size, len(data_list))))
+        if kwargs["nproc"] > 1:
+          args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
+              for i in range(num_frames)]
+          with Pool(kwargs["nproc"]) as pool:
+            pool.map(_save_frame_worker, args_list)
+          # end
+        else:
+          for i in range(num_frames):
+            _update(i, data_list, figs[-1], kwargs)
+            plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+          # end
         # end
         kwargs["show"] = False  # do not show in this case
       # end
@@ -323,14 +347,23 @@ def animate(ctx, **kwargs):
         anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
       # end
     else:
-      for i in range(int(np.nanmin((min_size, len(data_list))))):
-        _update(i, data_list, figs[-1], kwargs)
-        plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+      num_frames = int(np.nanmin((min_size, len(data_list))))
+      if kwargs["nproc"] > 1:
+        args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
+            for i in range(num_frames)]
+        with Pool(kwargs["nproc"]) as pool:
+          pool.map(_save_frame_worker, args_list)
+        # end
+      else:
+        for i in range(num_frames):
+          _update(i, data_list, figs[-1], kwargs)
+          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+        # end
       # end
       kwargs["show"] = False  # do not show in this case
     # end
-      
-    
+
+
   else:
 
     #create main list of lists (non-multiblock case)
@@ -358,9 +391,18 @@ def animate(ctx, **kwargs):
         anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
       # end
     else:
-      for i in range(int(np.nanmin((min_size, len(data_list))))):
-        _update(i, data_list, figs[-1], kwargs)
-        plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+      num_frames = int(np.nanmin((min_size, len(data_list))))
+      if kwargs["nproc"] > 1:
+        args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
+            for i in range(num_frames)]
+        with Pool(kwargs["nproc"]) as pool:
+          pool.map(_save_frame_worker, args_list)
+        # end
+      else:
+        for i in range(num_frames):
+          _update(i, data_list, figs[-1], kwargs)
+          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
+        # end
       # end
       kwargs["show"] = False  # do not show in this case
     # end

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -238,6 +238,10 @@ def animate(ctx, **kwargs):
   verb_print(ctx, "Starting animate")
   data = ctx.obj["data"]
 
+  # Accept str or path-like input for --saveas (e.g. a pathlib.Path).
+  if kwargs["saveas"]:
+    kwargs["saveas"] = str(kwargs["saveas"])
+  # end
   if kwargs["saveas"] and not kwargs["saveas"].lower().endswith(".gif"):
     raise click.ClickException("Currently only .gif output is supported for animations; please specify a .gif file with --saveas.")
   # end

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -1,5 +1,8 @@
+import os
+import tempfile
 from matplotlib.animation import FuncAnimation
 from multiprocessing import Pool
+from PIL import Image
 import click
 import matplotlib
 import matplotlib.pyplot as plt
@@ -12,11 +15,40 @@ import postgkyl.output.plot
 def _save_frame_worker(args):
   """Worker for parallel frame saving; each process creates its own figure."""
   matplotlib.use("Agg")
-  frame_idx, frame_data, kwargs, saveframes, dpi, figsize = args
+  frame_idx, frame_data, kwargs, prefix, dpi, figsize = args
   fig = plt.figure(figsize=figsize)
   _update(0, [frame_data], fig, kwargs)
-  plt.savefig(f"{saveframes:s}_{frame_idx:d}.png", dpi=dpi)
+  plt.savefig(f"{prefix:s}_{frame_idx:d}.png", dpi=dpi)
   plt.close(fig)
+# end
+
+
+def _save_frames(data_list, num_frames, prefix, kwargs, figsize, fig=None):
+  """Save frames as PNGs, using parallel workers when nproc > 1."""
+  if kwargs["nproc"] > 1:
+    args_list = [(i, data_list[i], kwargs, prefix, kwargs["dpi"], figsize)
+        for i in range(num_frames)]
+    with Pool(kwargs["nproc"]) as pool:
+      pool.map(_save_frame_worker, args_list)
+    # end
+  else:
+    for i in range(num_frames):
+      _update(i, data_list, fig, kwargs)
+      plt.savefig(f"{prefix:s}_{i:d}.png", dpi=kwargs["dpi"])
+    # end
+  # end
+# end
+
+
+def _compile_movie(frame_files, output_file, duration):
+  """Compile a list of PNG frame files into an animated GIF (or other PIL-supported format)."""
+  images = [Image.open(f) for f in frame_files]
+  print(f"Creating movie {output_file}...")
+  images[0].save(
+      output_file, save_all=True, append_images=images[1:],
+      duration=duration, loop=0, optimize=False,
+  )
+  print(f"Movie {output_file} created.")
 # end
 
 
@@ -182,9 +214,10 @@ def globalrange(data,kwargs):
 @click.option("--hashtag", is_flag=True, help="Turns on the pgkyl hashtag!")
 @click.option("--show/--no-show", default=True, help="Turn showing of the plot ON and OFF.")
 @click.option("--saveframes", type=click.STRING,
-    help="Save individual frames as PNGS instead of an animation")
+    help="Save individual frames as PNGs; also compiles a movie if --save or --saveas is given.")
 @click.option("--nproc", default=1, type=click.INT, show_default=True,
-    help="Number of parallel processes for saving frames (requires --saveframes).")
+    help="Number of parallel processes for frame generation. When >1 without --saveframes, "
+         "frames are written to a temp directory, compiled into a movie, then removed.")
 @click.option("--figsize", help="Comma-separated values for x and y size.")
 @click.option("-m", "--multiblock", is_flag=True, help="Plots blocks from each frame together")
 @click.pass_context
@@ -192,7 +225,8 @@ def animate(ctx, **kwargs):
   """Animate the actively loaded dataset and show resulting plots in a loop.
 
   Typically, the datasets are loaded using wildcard/regex feature of the -f option to
-  the main pgkyl executable. To save the animation ffmpeg needs to be installed.
+  the main pgkyl executable. Saving via --saveframes or --nproc uses Pillow (GIF by
+  default); the interactive FuncAnimation path still requires ffmpeg.
   """
   verb_print(ctx, "Starting animate")
   data = ctx.obj["data"]
@@ -238,6 +272,7 @@ def animate(ctx, **kwargs):
     figsize = (int(kwargs["figsize"].split(",")[0]), int(kwargs["figsize"].split(",")[1]))
   # end
 
+  duration = int(1000 / kwargs["fps"]) if kwargs["fps"] else kwargs["interval"]
 
   set_figure = False
   min_size = np.NAN
@@ -249,7 +284,7 @@ def animate(ctx, **kwargs):
       num_datasets = int(data.get_num_datasets(tag=tag))
       min_size = int(np.nanmin((min_size, num_datasets)))
     # end
-    
+
     tag_iterator = list(data.tag_iterator(kwargs["use"]))
     kwargs["legend"] = True
     set_figure = True
@@ -278,40 +313,39 @@ def animate(ctx, **kwargs):
       # end
       figs.append(plt.figure(fig_num, figsize=figsize))
       fig_num += 1
-      
-      if not kwargs["saveframes"]:
+
+      num_frames = int(np.nanmin((min_size, len(data_list))))
+      file_name = f"anim_{tag:s}.gif" if tag is not None else "anim.gif"
+      if kwargs["saveas"]:
+        file_name = str(kwargs["saveas"])
+      # end
+
+      if kwargs["saveframes"]:
+        # Save PNGs, then optionally compile a movie.
+        _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
+        if kwargs["save"] or kwargs["saveas"]:
+          frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
+          _compile_movie(frame_files, file_name, duration)
+        # end
+        kwargs["show"] = False
+      elif kwargs["nproc"] > 1:
+        # Parallel: use a temp dir, compile, then clean up.
+        with tempfile.TemporaryDirectory() as tmpdir:
+          tmp_prefix = os.path.join(tmpdir, "frame")
+          _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
+          frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
+          _compile_movie(frame_files, file_name, duration)
+        # end
+        kwargs["show"] = False
+      else:
         anims.append(
-            FuncAnimation(figs[-1], _update, int(np.nanmin((min_size, len(data_list)))),
+            FuncAnimation(figs[-1], _update, num_frames,
                 fargs=(data_list, figs[-1], kwargs), interval=kwargs["interval"],
                 blit=False)
         )
-
-        if tag is not None:
-          file_name = f"anim_{tag:s}.mp4"
-        else:
-          file_name = "anim.mp4"
-        # end
-        if kwargs["saveas"]:
-          file_name = str(kwargs["saveas"])
-        # end
         if kwargs["save"] or kwargs["saveas"]:
           anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
         # end
-      else:
-        num_frames = int(np.nanmin((min_size, len(data_list))))
-        if kwargs["nproc"] > 1:
-          args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
-              for i in range(num_frames)]
-          with Pool(kwargs["nproc"]) as pool:
-            pool.map(_save_frame_worker, args_list)
-          # end
-        else:
-          for i in range(num_frames):
-            _update(i, data_list, figs[-1], kwargs)
-            plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
-          # end
-        # end
-        kwargs["show"] = False  # do not show in this case
       # end
     # end
   #animation code for multiblock case
@@ -333,36 +367,35 @@ def animate(ctx, **kwargs):
     if (not kwargs["color"] and data_list[0][0].get_num_dims() == 1):
       kwargs["color"] = "tab:blue"
     # end
-    if not kwargs["saveframes"]:
+
+    num_frames = int(np.nanmin((min_size, len(data_list))))
+    file_name = kwargs["saveas"] if kwargs["saveas"] else "anim.gif"
+
+    if kwargs["saveframes"]:
+      _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
+      if kwargs["save"] or kwargs["saveas"]:
+        frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
+        _compile_movie(frame_files, file_name, duration)
+      # end
+      kwargs["show"] = False
+    elif kwargs["nproc"] > 1:
+      with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_prefix = os.path.join(tmpdir, "frame")
+        _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
+        frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
+        _compile_movie(frame_files, file_name, duration)
+      # end
+      kwargs["show"] = False
+    else:
       anims.append(
-          FuncAnimation(figs[-1], _update, int(np.nanmin((min_size, len(data_list)))),
+          FuncAnimation(figs[-1], _update, num_frames,
               fargs=(data_list, figs[-1], kwargs), interval=kwargs["interval"],
               blit=False)
       )
-      file_name = "anim.mp4"
-      if kwargs["saveas"]:
-        file_name = str(kwargs["saveas"])
-      # end
       if kwargs["save"] or kwargs["saveas"]:
         anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
       # end
-    else:
-      num_frames = int(np.nanmin((min_size, len(data_list))))
-      if kwargs["nproc"] > 1:
-        args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
-            for i in range(num_frames)]
-        with Pool(kwargs["nproc"]) as pool:
-          pool.map(_save_frame_worker, args_list)
-        # end
-      else:
-        for i in range(num_frames):
-          _update(i, data_list, figs[-1], kwargs)
-          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
-        # end
-      # end
-      kwargs["show"] = False  # do not show in this case
     # end
-
 
   else:
 
@@ -376,35 +409,34 @@ def animate(ctx, **kwargs):
     else:
       figs.append(plt.figure(figsize=figsize))
     # end
-    if not kwargs["saveframes"]:
+
+    num_frames = int(np.nanmin((min_size, len(data_list))))
+    file_name = kwargs["saveas"] if kwargs["saveas"] else "anim.gif"
+
+    if kwargs["saveframes"]:
+      _save_frames(data_list, num_frames, kwargs["saveframes"], kwargs, figsize, figs[-1])
+      if kwargs["save"] or kwargs["saveas"]:
+        frame_files = [f"{kwargs['saveframes']}_{i}.png" for i in range(num_frames)]
+        _compile_movie(frame_files, file_name, duration)
+      # end
+      kwargs["show"] = False
+    elif kwargs["nproc"] > 1:
+      with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_prefix = os.path.join(tmpdir, "frame")
+        _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
+        frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
+        _compile_movie(frame_files, file_name, duration)
+      # end
+      kwargs["show"] = False
+    else:
       anims.append(
-          FuncAnimation(figs[-1], _update, int(np.nanmin((min_size, len(data_list)))),
+          FuncAnimation(figs[-1], _update, num_frames,
               fargs=(data_list, figs[-1], kwargs), interval=kwargs["interval"],
               blit=False)
       )
-
-      file_name = "anim.mp4"
-      if kwargs["saveas"]:
-        file_name = str(kwargs["saveas"])
-      # end
       if kwargs["save"] or kwargs["saveas"]:
         anims[-1].save(file_name, writer="ffmpeg", fps=kwargs["fps"], dpi=kwargs["dpi"])
       # end
-    else:
-      num_frames = int(np.nanmin((min_size, len(data_list))))
-      if kwargs["nproc"] > 1:
-        args_list = [(i, data_list[i], kwargs, kwargs["saveframes"], kwargs["dpi"], figsize)
-            for i in range(num_frames)]
-        with Pool(kwargs["nproc"]) as pool:
-          pool.map(_save_frame_worker, args_list)
-        # end
-      else:
-        for i in range(num_frames):
-          _update(i, data_list, figs[-1], kwargs)
-          plt.savefig(f"{kwargs['saveframes']:s}_{i:d}.png", dpi=kwargs["dpi"])
-        # end
-      # end
-      kwargs["show"] = False  # do not show in this case
     # end
   # end
 

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -221,10 +221,9 @@ def globalrange(data,kwargs):
 @click.option("--hashtag", is_flag=True, help="Turns on the pgkyl hashtag!")
 @click.option("--show/--no-show", default=True, help="Turn showing of the plot ON and OFF.")
 @click.option("--saveframes", type=click.STRING,
-    help="Save individual frames as PNGs; also compiles a movie if --save or --saveas is given.")
+    help="Save individual frames as PNGs.")
 @click.option("--nproc", default=1, type=click.INT, show_default=True,
-    help="Number of parallel processes for frame generation. When >1 without --saveframes, "
-         "frames are written to a temp directory, compiled into a movie, then removed.")
+    help="Number of parallel processes for frame generation.")
 @click.option("--figsize", help="Comma-separated values for x and y size.")
 @click.option("-m", "--multiblock", is_flag=True, help="Plots blocks from each frame together")
 @click.pass_context
@@ -232,8 +231,7 @@ def animate(ctx, **kwargs):
   """Animate the actively loaded dataset and show resulting plots in a loop.
 
   Typically, the datasets are loaded using wildcard/regex feature of the -f option to
-  the main pgkyl executable. Saving via --saveframes or --nproc uses Pillow (GIF by
-  default); the interactive FuncAnimation path still requires ffmpeg.
+  the main pgkyl executable.
   """
   verb_print(ctx, "Starting animate")
   data = ctx.obj["data"]

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -284,7 +284,8 @@ def animate(ctx, **kwargs):
     figsize = (int(kwargs["figsize"].split(",")[0]), int(kwargs["figsize"].split(",")[1]))
   # end
 
-  duration = int(1000 / kwargs["fps"]) if kwargs["fps"] else kwargs["interval"]
+  # PIL requires duration in miliseconds.
+  duration = int(1.0e3 / kwargs["fps"]) if kwargs["fps"] else kwargs["interval"]
 
   set_figure = False
   min_size = np.NAN

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -43,7 +43,6 @@ def _save_frames(data_list, num_frames, prefix, kwargs, figsize, fig=None):
 def _compile_movie(frame_files, output_file, fps, duration):
   """Compile PNG frames into an animation."""
   ext = os.path.splitext(output_file)[1].lower()
-  fps_val = fps if fps else 10
   print(f"Creating {output_file}...")
   if ext in (".gif", ".webp", ".apng"):
     images = [Image.open(f) for f in frame_files]

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -246,7 +246,7 @@ def globalrange(data,kwargs):
 @click.option("--nproc", default=1, type=click.INT, show_default=True,
     help="Number of parallel processes for frame generation.")
 @click.option("--tmpdir", default=None, type=click.STRING, show_default=True,
-    help="Temporary directory for parallel frame generation.")
+    help="Directory to place the temporary directory for parallel frame generation.")
 @click.option("--figsize", help="Comma-separated values for x and y size.")
 @click.option("-m", "--multiblock", is_flag=True, help="Plots blocks from each frame together")
 @click.pass_context

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -211,7 +211,7 @@ def globalrange(data,kwargs):
 @click.option("--notitle", is_flag=True, help="Do not show title.")
 @click.option("-i", "--interval", default=100, help="Specify the animation interval.")
 @click.option("--save", is_flag=True, help="Save figure as PNG.")
-@click.option("--saveas", type=click.STRING, default=None, help="Name to save the plot as. Use .gif please.")
+@click.option("--saveas", type=click.STRING, default=None, help="Name to save the plot as.")
 @click.option("--fps", type=click.INT, help="Specify frames per second for saving.")
 @click.option("--dpi", type=click.INT, help="DPI (resolution) for output.")
 @click.option("-e", "--edgecolors", type=click.STRING, help="Set color for cell edges.")

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -1,6 +1,7 @@
 import os
+import shutil
 import tempfile
-from matplotlib.animation import FuncAnimation
+from matplotlib.animation import FuncAnimation, FFMpegWriter
 from multiprocessing import Pool
 from PIL import Image
 import click
@@ -10,6 +11,9 @@ import numpy as np
 
 from postgkyl.utils import verb_print, set_frame
 import postgkyl.output.plot
+
+# Formats written through ffmpeg (PIL cannot produce these video containers).
+VIDEO_EXTS = (".mp4", ".mov", ".avi", ".mkv")
 
 
 def _save_frame_worker(args):
@@ -50,10 +54,28 @@ def _compile_movie(frame_files, output_file, fps, duration):
         output_file, save_all=True, append_images=images[1:],
         duration=duration, loop=0, optimize=False,
     )
+  elif ext in VIDEO_EXTS:
+    # PIL cannot write video containers; use matplotlib's ffmpeg writer.
+    # duration is in milliseconds per frame, so fall back to it when fps is unset.
+    movie_fps = fps if fps else 1.0e3 / duration
+    writer = FFMpegWriter(fps=movie_fps)
+    first = Image.open(frame_files[0])
+    dpi = 100
+    fig = plt.figure(figsize=(first.width / dpi, first.height / dpi), dpi=dpi)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.axis("off")
+    with writer.saving(fig, output_file, dpi):
+      for frame_file in frame_files:
+        ax.clear()
+        ax.axis("off")
+        ax.imshow(Image.open(frame_file))
+        writer.grab_frame()
+      # end
+    # end
+    plt.close(fig)
   else:
-    # We do not support other format like .mp4 or .avi.
     raise ValueError(f"Unsupported output format: {ext}")
-    
+
   print(f"{output_file} created.")
 # end
 
@@ -239,8 +261,18 @@ def animate(ctx, **kwargs):
   if kwargs["saveas"]:
     kwargs["saveas"] = str(kwargs["saveas"])
   # end
-  if kwargs["saveas"] and not kwargs["saveas"].lower().endswith(".gif"):
-    raise click.ClickException("Currently only .gif output is supported for animations; please specify a .gif file with --saveas.")
+  supported_exts = (".gif", ".webp", ".apng") + VIDEO_EXTS
+  if kwargs["saveas"] and not kwargs["saveas"].lower().endswith(supported_exts):
+    raise click.ClickException(
+        "Unsupported output format for --saveas; please use one of: "
+        + ", ".join(supported_exts) + ".")
+  # end
+  # Video containers are written through ffmpeg, which must be on the PATH.
+  if kwargs["saveas"] and kwargs["saveas"].lower().endswith(VIDEO_EXTS) \
+      and shutil.which("ffmpeg") is None:
+    raise click.ClickException(
+        "ffmpeg is required to write " + ", ".join(VIDEO_EXTS) + " files but was "
+        "not found. Please install ffmpeg or choose a .gif output instead.")
   # end
 
   if kwargs["xlim"]:

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -163,31 +163,31 @@ def globalrange(data,kwargs):
 @click.command()
 @click.option("--use", "-u", default=None, help="Specify a tag to plot.")
 @click.option("--grouptags", is_flag=True, help="Group coresponding tagged frames.")
-@click.option("--squeeze", "-s", is_flag=True, help="Squeeze the components into one panel.")
+@click.option("--squeeze", "-p", is_flag=True, help="Squeeze the components into one panel.")
 @click.option("--subplots", "-b", is_flag=True, help="Make subplots from multiple datasets.")
 @click.option("--nsubplotrow", "nSubplotRow", type=click.INT,
     help="Manually set the number of rows for subplots.")
 @click.option("--nsubplotcol", "nSubplotCol", type=click.INT,
     help="Manually set the number of columns for subplots.")
 @click.option("--transpose", is_flag=True, help="Transpose axes.")
-@click.option("-c", "--contour", is_flag=True, help="Make contour plot.")
+@click.option("--contour", "-c", is_flag=True, help="Make contour plot.")
 @click.option("--clevels", type=click.STRING,
     help="Specify levels for contours: either integer or start:end:nlevels")
-@click.option("-q", "--quiver", is_flag=True, help="Make quiver plot.")
-@click.option("-l", "--streamline", is_flag=True, help="Make streamline plot.")
+@click.option("--quiver", "-q", is_flag=True, help="Make quiver plot.")
+@click.option("--streamline", "-l", is_flag=True, help="Make streamline plot.")
 @click.option("--sdensity", type=click.FLOAT, help="Control density of the streamlines.")
 @click.option("--arrowstyle", type=click.STRING, help="Set the style for streamline arrows.")
-@click.option("-g", "--group", type=click.Choice(["0", "1"]), help="Switch to group mode.")
-@click.option("-s", "--scatter", is_flag=True, help="Make scatter plot.")
+@click.option("--group", "-g", type=click.Choice(["0", "1"]), help="Switch to group mode.")
+@click.option("--scatter", "-s", is_flag=True, help="Make scatter plot.")
 @click.option("--markersize", type=click.FLOAT, help="Set marker size for scatter plots.")
 @click.option("--linewidth", type=click.FLOAT, help="Set the linewidth.")
 @click.option("--linestyle", type=click.Choice(["solid", "dashed", "dotted", "dashdot"]),
     help="Set the linestyle.")
 @click.option("--color", type=click.STRING, help="Set color when available.")
 @click.option("--style", help="Specify Matplotlib style file (default: Postgkyl).")
-@click.option("-d", "--diverging", is_flag=True, help="Switch to diverging colormesh mode.")
+@click.option("--diverging", "-d", is_flag=True, help="Switch to diverging colormesh mode.")
 @click.option("--arg", type=click.STRING, help="Additional plotting arguments, e.g., '*--'.")
-@click.option("-a", "--fix-aspect", "fixaspect", is_flag=True,
+@click.option("--fix-aspect", "-a", "fixaspect", is_flag=True,
     help="Enforce the same scaling on both axes.")
 @click.option("--logx", is_flag=True, help="Set x-axis to log scale.")
 @click.option("--logy", is_flag=True, help="Set y-axis to log scale.")
@@ -235,7 +235,7 @@ def globalrange(data,kwargs):
 @click.option("--saveas", type=click.STRING, default=None, help="Name to save the plot as.")
 @click.option("--fps", type=click.INT, help="Specify frames per second for saving.")
 @click.option("--dpi", type=click.INT, help="DPI (resolution) for output.")
-@click.option("-e", "--edgecolors", type=click.STRING, help="Set color for cell edges.")
+@click.option("--edgecolors", "-e", type=click.STRING, help="Set color for cell edges.")
 @click.option("--showgrid/--no-showgrid", default=True, help="Show grid-lines.")
 @click.option("--collected", is_flag=True,
    help="Animate a dataset that has been collected, i.e. a single dataset with time taken to be the first index.")

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -245,6 +245,8 @@ def globalrange(data,kwargs):
     help="Save individual frames as PNGs.")
 @click.option("--nproc", default=1, type=click.INT, show_default=True,
     help="Number of parallel processes for frame generation.")
+@click.option("--tmpdir", default=None, type=click.STRING, show_default=True,
+    help="Temporary directory for parallel frame generation.")
 @click.option("--figsize", help="Comma-separated values for x and y size.")
 @click.option("-m", "--multiblock", is_flag=True, help="Plots blocks from each frame together")
 @click.pass_context
@@ -375,7 +377,7 @@ def animate(ctx, **kwargs):
         kwargs["show"] = False
       elif kwargs["nproc"] > 1:
         # Parallel: use a temp dir, compile, then clean up.
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=kwargs["tmpdir"]) as tmpdir:
           tmp_prefix = os.path.join(tmpdir, "frame")
           _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
           frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
@@ -424,7 +426,7 @@ def animate(ctx, **kwargs):
       # end
       kwargs["show"] = False
     elif kwargs["nproc"] > 1:
-      with tempfile.TemporaryDirectory() as tmpdir:
+      with tempfile.TemporaryDirectory(dir=kwargs["tmpdir"]) as tmpdir:
         tmp_prefix = os.path.join(tmpdir, "frame")
         _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
         frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]
@@ -466,7 +468,7 @@ def animate(ctx, **kwargs):
       # end
       kwargs["show"] = False
     elif kwargs["nproc"] > 1:
-      with tempfile.TemporaryDirectory() as tmpdir:
+      with tempfile.TemporaryDirectory(dir=kwargs["tmpdir"]) as tmpdir:
         tmp_prefix = os.path.join(tmpdir, "frame")
         _save_frames(data_list, num_frames, tmp_prefix, kwargs, figsize)
         frame_files = [f"{tmp_prefix}_{i}.png" for i in range(num_frames)]

--- a/src/postgkyl/commands/animate.py
+++ b/src/postgkyl/commands/animate.py
@@ -47,7 +47,7 @@ def _save_frames(data_list, num_frames, prefix, kwargs, figsize, fig=None):
 def _compile_movie(frame_files, output_file, fps, duration):
   """Compile PNG frames into an animation."""
   ext = os.path.splitext(output_file)[1].lower()
-  print(f"Creating {output_file}...")
+  verb_print(f"Creating {output_file}...")
   if ext in (".gif", ".webp", ".apng"):
     images = [Image.open(f) for f in frame_files]
     images[0].save(
@@ -76,7 +76,7 @@ def _compile_movie(frame_files, output_file, fps, duration):
   else:
     raise ValueError(f"Unsupported output format: {ext}")
 
-  print(f"{output_file} created.")
+  verb_print(f"{output_file} created.")
 # end
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -149,9 +149,7 @@ class TestCommands:
     plt.close("all")
     assert label == "$z_1$"
 
-
-  @pytest.mark.skipif(ffmpeg_missing, reason="ffmpeg is not installed")
-  def test_animate_save(self, tmp_path):
+  def test_animate_save_gif(self, tmp_path):
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.load)
     fn = tmp_path / "test_anim.gif"
@@ -164,6 +162,19 @@ class TestCommands:
     assert label == "$z_1$"
     assert fn.exists()
 
+  @pytest.mark.skipif(ffmpeg_missing, reason="ffmpeg is not installed")
+  def test_animate_save_mp4(self, tmp_path):
+    self.ctx.invoke(cmd.load)
+    self.ctx.invoke(cmd.load)
+    fn = tmp_path / "test_anim.mp4"
+    self.ctx.invoke(cmd.animate, show=False, saveas=fn)
+    fig = plt.gcf()
+    label = fig.figure.get_supylabel()
+    self.ctx.obj['data'].clean()
+    self.ctx.obj["in_data_strings_loaded"] = 0
+    plt.close("all")
+    assert label == "$z_1$"
+    assert fn.exists()
 
   def test_grid(self):
     self.ctx.invoke(cmd.load)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -154,7 +154,7 @@ class TestCommands:
   def test_animate_save(self, tmp_path):
     self.ctx.invoke(cmd.load)
     self.ctx.invoke(cmd.load)
-    fn = tmp_path / "test_anim.mp4"
+    fn = tmp_path / "test_anim.gif"
     self.ctx.invoke(cmd.animate, show=False, saveas=fn)
     fig = plt.gcf()
     label = fig.figure.get_supylabel()


### PR DESCRIPTION
This implements the possibility to generate movies with a parallelization of the frame generation.

One can now run `animate` with `--nproc` command which will generate the animation using a number of processes bigger than 1. If `--nproc` is not specified, the code do not change.

We now ensure that the movie file given is a `.gif`, I don't know how to generate `.mp4` robustly and I think the user can use a gif 2 mp4 converter afterwards if needed.

<img width="640" height="480" alt="tcv_nt_ion_M0" src="https://github.com/user-attachments/assets/bed69822-d7e8-4c06-9830-15955176380b" />

The animation above was generated on perlmutter login node. It took 30sec in sequential agains 12 with 4 processes, here is the command line 
```
pgkyl /pscratch/sd/a/ah1032/gkeyll_em/tcv_pt_0.5MW_coarse/smoothapar/wk_restart/rt_gk_tcv_nt_iwl_adapt_src_3x2v_p1-ion_M0_[0-9]*.gkyl gk-dg select --z1 0.0 --z2 0.0 -ylim 0,7e19 --saveas tcv_nt_ion_M0.gif --saveframes tmp/ --nproc 4
```

### note
For a very basic movie in 1D, We can easily divide the time to generate the animation by 2. Then the time start to be dominated by the postprocessing like `interp` `sel` etc.  
For heavier post processing task like `gk-rz` for multiple frames, one could consider having another layer in the API that would run the entire command in parallel to generate frames and then compiling the frames.