### PR TITLE
Add an interface to use gk-distf through the gk-load-quantity.

### DIFF
--- a/src/postgkyl/utils/gk_quantities/fetch_funcs.py
+++ b/src/postgkyl/utils/gk_quantities/fetch_funcs.py
@@ -528,3 +528,35 @@ def fetch_diamag_vel(gdatas, **kwargs):
   out.set_values(out.get_values()/charge)
 
   return out
+
+# -------------------------------------------------------------------------
+# --- Custom loaders (loader_func signature: path, name, species, frame) ---
+# -------------------------------------------------------------------------
+
+def load_distf(path: str, name: str, species: str, frame: int, **extra) -> GData:
+  """
+  Loader for the registry 'distf' quantity. Wraps load_gk_distf with defaults
+  tailored to registry use: never interpolate (interp=0) and convert velocity
+  coordinates (c2p_vel) on by default.
+
+  Defaults can be overridden via --extra, e.g.:
+    -e suffix=source      use <name>-<species>_source_<frame>.gkyl as input
+    -e c2p_vel=0          disable velocity-space mapping
+    -e mc2nu=1            apply non-uniform -> field-aligned position mapping
+    -e mapc2p=1           apply position-space -> Cartesian/cylindrical mapping
+    -e block=2            load only the 2nd block of a multi-block file
+  """
+  from postgkyl.commands.gk_distf import load_gk_distf
+  from postgkyl.utils.gk_utils import dict_get_bool
+
+  prefix = path.rstrip("/") + "/" + name
+
+  return load_gk_distf(
+    name=prefix, species=species, frame=int(frame),
+    suffix=str(extra.get("suffix", "")),
+    use_c2p_vel=dict_get_bool(extra, "c2p_vel", True),
+    use_mc2nu=dict_get_bool(extra, "mc2nu", False),
+    use_mapc2p=dict_get_bool(extra, "mapc2p", False),
+    block_idx=extra.get("block", None),
+    interp=0,  # registry distf always works with non-interpolated DG data
+  )

--- a/src/postgkyl/utils/gk_quantities/fetch_funcs.py
+++ b/src/postgkyl/utils/gk_quantities/fetch_funcs.py
@@ -529,11 +529,7 @@ def fetch_diamag_vel(gdatas, **kwargs):
 
   return out
 
-# -------------------------------------------------------------------------
-# --- Custom loaders (loader_func signature: path, name, species, frame) ---
-# -------------------------------------------------------------------------
-
-def load_distf(path: str, name: str, species: str, frame: int, **extra) -> GData:
+def load_distf(gdatas, **kwargs) -> GData:
   """
   Loader for the registry 'distf' quantity. Wraps load_gk_distf with defaults
   tailored to registry use: never interpolate (interp=0) and convert velocity
@@ -549,10 +545,11 @@ def load_distf(path: str, name: str, species: str, frame: int, **extra) -> GData
   from postgkyl.commands.gk_distf import load_gk_distf
   from postgkyl.utils.gk_utils import dict_get_bool
 
-  prefix = path.rstrip("/") + "/" + name
+  prefix = kwargs.get("path", "").rstrip("/") + "/" + kwargs.get("name", "")
+  extra = kwargs.get("extra", {})
 
   return load_gk_distf(
-    name=prefix, species=species, frame=int(frame),
+    name=prefix, species=kwargs.get("species", ""), frame=int(kwargs.get("frame", 0)),
     suffix=str(extra.get("suffix", "")),
     use_c2p_vel=dict_get_bool(extra, "c2p_vel", True),
     use_mc2nu=dict_get_bool(extra, "mc2nu", False),

--- a/src/postgkyl/utils/gk_quantities/gkquantity.py
+++ b/src/postgkyl/utils/gk_quantities/gkquantity.py
@@ -15,10 +15,12 @@ class GkQuantity:
     is_time_dep: If the quantity is time-dependent (i.e. written in frames).
     is_species_dep: If the quantity is species-dependent.
     is_vector: If the quantity is a vector (i.e. has multiple components).
+    loader_func: Optional custom loader which bypasses the fetch machinery.
   """
   name = None
   source = None
   fetch_func = None
+  loader_func = None
   label = None
   is_time_dep = None
   is_species_dep = None
@@ -29,10 +31,12 @@ class GkQuantity:
 
   def __init__(self, name : str, source : list, fetch_func : callable, label : str,
                is_time_dep : bool = False, is_species_dep : bool = False, is_vector : bool = False,
-               is_tensor : bool = False, is_integrated : bool = False, is_geo : bool = False):
+               is_tensor : bool = False, is_integrated : bool = False, is_geo : bool = False,
+               loader_func : callable = None):
     self.name = name
     self.source = source
     self.fetch_func = fetch_func
+    self.loader_func = loader_func
     self.label = label
     self.is_time_dep = is_time_dep
     self.is_species_dep = is_species_dep
@@ -51,7 +55,8 @@ class GkQuantity:
     if self.is_geo:
       return os.path.join(path, f"{name}-{src}")
     elif self.is_species_dep:
-      return os.path.join(path, f"{name}-{species}_{src}_")
+      src_ = f"{src}_" if src else ""
+      return os.path.join(path, f"{name}-{species}_{src_}")
     else:
       return os.path.join(path, f"{name}-{src}_")
 
@@ -209,9 +214,12 @@ class GkQuantity:
   def fetch(self, path : str, name : str, species : str, frame : int | None,
             combo_idx : int, **extra) -> GData:
     """
-    Load this quantity's sources for the given combination and frame, then
-    compute and return the resulting GData.
+    Return the GData associated with this quantity, either with a custom
+    loader_func or by fetching the source files and computing the quantity.
     """
+    if self.loader_func is not None:
+      return self.loader_func(path, name, species, frame, **extra)
+
     combo = self.source[combo_idx]
     fetch_func = self.fetch_func[combo_idx]
     gdatas = [self.get_src_gdata(src, path, name, species, frame, **extra) for src in combo]

--- a/src/postgkyl/utils/gk_quantities/gkquantity.py
+++ b/src/postgkyl/utils/gk_quantities/gkquantity.py
@@ -15,7 +15,6 @@ class GkQuantity:
     is_time_dep: If the quantity is time-dependent (i.e. written in frames).
     is_species_dep: If the quantity is species-dependent.
     is_vector: If the quantity is a vector (i.e. has multiple components).
-    loader_func: Optional custom loader which bypasses the fetch machinery.
   """
   name = None
   source = None

--- a/src/postgkyl/utils/gk_quantities/gkquantity.py
+++ b/src/postgkyl/utils/gk_quantities/gkquantity.py
@@ -20,7 +20,6 @@ class GkQuantity:
   name = None
   source = None
   fetch_func = None
-  loader_func = None
   label = None
   is_time_dep = None
   is_species_dep = None
@@ -31,12 +30,10 @@ class GkQuantity:
 
   def __init__(self, name : str, source : list, fetch_func : callable, label : str,
                is_time_dep : bool = False, is_species_dep : bool = False, is_vector : bool = False,
-               is_tensor : bool = False, is_integrated : bool = False, is_geo : bool = False,
-               loader_func : callable = None):
+               is_tensor : bool = False, is_integrated : bool = False, is_geo : bool = False):
     self.name = name
     self.source = source
     self.fetch_func = fetch_func
-    self.loader_func = loader_func
     self.label = label
     self.is_time_dep = is_time_dep
     self.is_species_dep = is_species_dep
@@ -214,15 +211,17 @@ class GkQuantity:
   def fetch(self, path : str, name : str, species : str, frame : int | None,
             combo_idx : int, **extra) -> GData:
     """
-    Return the GData associated with this quantity, either with a custom
-    loader_func or by fetching the source files and computing the quantity.
+    Return the GData associated with this quantit by fetching the source files 
+    and computing the quantity.
     """
-    if self.loader_func is not None:
-      return self.loader_func(path, name, species, frame, **extra)
-
     combo = self.source[combo_idx]
     fetch_func = self.fetch_func[combo_idx]
     gdatas = [self.get_src_gdata(src, path, name, species, frame, **extra) for src in combo]
+    # Pass the path, name, species, and frame to the fetch function in case it needs them.
+    extra["path"] = path
+    extra["name"] = name
+    extra["species"] = species
+    extra["frame"] = frame
     return fetch_func(gdatas, **extra)
 
 

--- a/src/postgkyl/utils/gk_quantities/registry.py
+++ b/src/postgkyl/utils/gk_quantities/registry.py
@@ -293,8 +293,7 @@ gk_quant_registry.register(_diamag_vel)
 _distf : GkQuantity = GkQuantity(
   name = "distf",
   source = [[""]],
-  fetch_func = [None],
-  loader_func = ff.load_distf,
+  fetch_func = [ff.load_distf],
   label = r"$f_{%s}$",
   is_time_dep = True,
   is_species_dep = True,

--- a/src/postgkyl/utils/gk_quantities/registry.py
+++ b/src/postgkyl/utils/gk_quantities/registry.py
@@ -273,6 +273,22 @@ _gradB_vel : GkQuantity = GkQuantity(
 )
 gk_quant_registry.register(_gradB_vel)
 
+# ------------------------------
+# --- Phase space quantities ---
+# ------------------------------
+
+# Distribution function loaded through load_gk_distf.
+_distf : GkQuantity = GkQuantity(
+  name = "distf",
+  source = [[""]],
+  fetch_func = [None],
+  loader_func = ff.load_distf,
+  label = r"$f_{%s}$",
+  is_time_dep = True,
+  is_species_dep = True,
+)
+gk_quant_registry.register(_distf)
+
 # Diamagnetic drift velocity.
 _diamag_vel : GkQuantity = GkQuantity(
   name = "diamag_vel",

--- a/src/postgkyl/utils/gk_quantities/registry.py
+++ b/src/postgkyl/utils/gk_quantities/registry.py
@@ -273,6 +273,18 @@ _gradB_vel : GkQuantity = GkQuantity(
 )
 gk_quant_registry.register(_gradB_vel)
 
+# Diamagnetic drift velocity.
+_diamag_vel : GkQuantity = GkQuantity(
+  name = "diamag_vel",
+  source = [[_geo_int_jacobtot_inv,_geo_int_bmag,_geo_int_b_i, _M0, _pressperp]],
+  fetch_func= [ff.fetch_diamag_vel],
+  label = r"$v_{dia,%s}$ (m/s)",
+  is_time_dep = True,
+  is_species_dep = True,
+  is_vector = True
+)
+gk_quant_registry.register(_diamag_vel)
+
 # ------------------------------
 # --- Phase space quantities ---
 # ------------------------------
@@ -288,15 +300,3 @@ _distf : GkQuantity = GkQuantity(
   is_species_dep = True,
 )
 gk_quant_registry.register(_distf)
-
-# Diamagnetic drift velocity.
-_diamag_vel : GkQuantity = GkQuantity(
-  name = "diamag_vel",
-  source = [[_geo_int_jacobtot_inv,_geo_int_bmag,_geo_int_b_i, _M0, _pressperp]],
-  fetch_func= [ff.fetch_diamag_vel],
-  label = r"$v_{dia,%s}$ (m/s)",
-  is_time_dep = True,
-  is_species_dep = True,
-  is_vector = True
-)
-gk_quant_registry.register(_diamag_vel)

--- a/src/postgkyl/utils/gk_utils.py
+++ b/src/postgkyl/utils/gk_utils.py
@@ -72,6 +72,17 @@ def read_interp_gfile(file_name, poly_order, basis_type, comp=0):
 
   return grid_out, np.squeeze(vals), pgData
 
+def dict_get_bool(dict_in, key, default):
+  # Interpret a dictionary value as a bool, returning 'default' if the key is
+  # absent. String values '1'/'true' (case-insensitive) are True, anything
+  # else false. Non string values are converted using bool().
+  if key not in dict_in:
+    return default
+  val = dict_in[key]
+  if isinstance(val, str):
+    return val.strip().lower() in ("1", "true")
+  return bool(val)
+
 def parse_slice_string(value):
   # Parse a 'slice()' from string, like 'start:stop:step'.
   parts = value.split(':')


### PR DESCRIPTION
These changes allow us to write :
```
pgkyl gk-load-quantity -q distf -n rt_gk_tcv_iwl_adapt_source_1x2v_p1 -s elc -f 0
```
i.e. to use gk-loadq for distribution function as well. 
This is done by adding a new `loader_func` attribute to `GkQuantity` which allows to have an alternative way to load Gdata.
We can then add to the registry:
```Python
# Distribution function loaded through load_gk_distf.
_distf : GkQuantity = GkQuantity(
  name = "distf",
  source = [[""]],
  fetch_func = [None],
  loader_func = ff.load_distf,
  label = r"$f_{%s}$",
  is_time_dep = True,
  is_species_dep = True,
)
gk_quant_registry.register(_distf)
```
Where `ff.load_distf` is a small wrapper defined with the other fetch functions in `fetch_funcs.py`. This wrapper allows us to define some flags by default. For example, here we decide to always load the c2p_vel. We can modify that with the `--extra` command.