### PR TITLE
Fix transpose plot option

### DIFF
--- a/src/postgkyl/output/plot.py
+++ b/src/postgkyl/output/plot.py
@@ -135,7 +135,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     mpl.rcParams["lines.linestyle"] = linestyle
   # end
 
-  # ---- Data Loading ----
+  # Data Loading
   # Get the handles on the grid and values
   grid_in, values = input_parser(data)
   grid = grid_in.copy()
@@ -197,7 +197,6 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     # end
   # end
 
-  # ---- Optional axis transpose ----
   # Swap the horizontal and vertical axes.
   if transpose and num_dims == 2:
     values = np.swapaxes(values, 0, 1)
@@ -255,7 +254,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     xlabel, ylabel = ylabel, xlabel
   # end
 
-  # ---- Prepare Figure and Axes ----------------------------------------
+  # Prepare Figure and Axes
   if bool(figsize):
     figsize = (int(figsize.split(",")[0]), int(figsize.split(",")[1]))
   # end
@@ -353,7 +352,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     # end
   # end
 
-  # ---- Main Plotting Loop ---------------------------------------------
+  # Main Plotting Loop
   for comp in idx_comps:
     cax = ax[0] if squeeze else ax[comp + start_axes]
     label = f"{label_prefix:s}_c{comp:d}".strip("_") if len(idx_comps) > 1 else label_prefix
@@ -370,7 +369,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     elif num_dims == 2:
       extend = None
 
-      if contour:  # ----------------------------------------------------
+      if contour:
         levels = 10
         if cnlevels:
           levels = int(cnlevels) - 1
@@ -396,7 +395,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
           cax.clabel(im, inline=1)
         # end
 
-      elif quiver:  # ----------------------------------------------------
+      elif quiver:
         skip = int(np.max((len(grid[0]), len(grid[1])))//15)
         skip2 = int(skip//2)
         nodal_grid = _get_nodal_grid(grid, cells)
@@ -411,7 +410,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
         z2 = (values[skip2::skip, skip2::skip, 2 * comp + 1].transpose() + zshift)*zscale
         im = cax.quiver(x, y, z1, z2)
 
-      elif streamline:  # ------------------------------------------------
+      elif streamline:
         if bool(color):
           cl = color
         else:
@@ -428,7 +427,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
         im = cax.streamplot(x, y, z1, z2, *args,
             density=sdensity, broken_streamlines=False, color=cl, linewidth=linewidth)
 
-      elif lineouts is not None:  # -------------------------------------
+      elif lineouts is not None:
         num_lines = values.shape[1] if lineouts == 0 else values.shape[0]
         nodal_grid = _get_nodal_grid(grid, cells)
 
@@ -462,7 +461,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
         colorbar = False
         legend = False
 
-      else:  # -----------------------------------------------------------
+      else:
         if zmin is not None and zmax is not None:
           extend = "both"
         elif zmax is not None:
@@ -509,7 +508,7 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
       raise ValueError(f"{num_dims:d}D data not supported")
     # end
 
-    # ---- Additional Formatting ----------------------------------------
+    # Additional Formatting
     cax.grid(showgrid)
     # Legend
     if legend:

--- a/src/postgkyl/output/plot.py
+++ b/src/postgkyl/output/plot.py
@@ -59,7 +59,7 @@ def _get_nodal_grid(grid : list, cells: np.ndarray):
 
 def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     figure: int | matplotlib.figure.Figure | str | None = None,
-    squeeze: bool = False, num_axes: int = None, start_axes: int = 0,
+    squeeze: bool = False, transpose: bool = False, num_axes: int = None, start_axes: int = 0,
     num_subplot_row: int | None = None, num_subplot_col: int | None = None,
     streamline: bool = False, sdensity: int = 1,
     quiver: bool = False,
@@ -197,6 +197,21 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     # end
   # end
 
+    # ---- Optional axis transpose ----
+    # Swap the horizontal and vertical axes.
+    if transpose and num_dims == 2:
+      values = np.swapaxes(values, 0, 1)
+      g0, g1 = grid[1], grid[0]
+      if g0.ndim > 1:
+        g0, g1 = g0.transpose(), g1.transpose()
+      # end
+      grid[0], grid[1] = g0, g1
+      lower[0], lower[1] = lower[1], lower[0]
+      upper[0], upper[1] = upper[1], upper[0]
+      cells[0], cells[1] = cells[1], cells[0]
+      axes_labels[0], axes_labels[1] = axes_labels[1], axes_labels[0]
+    # end
+
   # Get the number of components and an indexer
   step = 2 if bool(streamline or quiver) else 1
   num_comps = values.shape[-1]
@@ -235,6 +250,10 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
       clabel = rf"$\times$ {zscale:.3e}"
     # end
   # end
+
+    if transpose and num_dims == 1:
+      xlabel, ylabel = ylabel, xlabel
+    # end
 
   # ---- Prepare Figure and Axes ----------------------------------------
   if bool(figsize):
@@ -343,6 +362,9 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
       nodal_grid = _get_nodal_grid(grid, cells)
       x = (nodal_grid[0] + xshift)*xscale
       y = (values[..., comp] + yshift)*yscale
+        if transpose:  # put the coordinate on the vertical axis
+          x, y = y, x
+        # end
       im = cax.plot(x, y, *args, color=color, label=label, markersize=markersize)
 
     elif num_dims == 2:

--- a/src/postgkyl/output/plot.py
+++ b/src/postgkyl/output/plot.py
@@ -197,20 +197,20 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     # end
   # end
 
-    # ---- Optional axis transpose ----
-    # Swap the horizontal and vertical axes.
-    if transpose and num_dims == 2:
-      values = np.swapaxes(values, 0, 1)
-      g0, g1 = grid[1], grid[0]
-      if g0.ndim > 1:
-        g0, g1 = g0.transpose(), g1.transpose()
-      # end
-      grid[0], grid[1] = g0, g1
-      lower[0], lower[1] = lower[1], lower[0]
-      upper[0], upper[1] = upper[1], upper[0]
-      cells[0], cells[1] = cells[1], cells[0]
-      axes_labels[0], axes_labels[1] = axes_labels[1], axes_labels[0]
+  # ---- Optional axis transpose ----
+  # Swap the horizontal and vertical axes.
+  if transpose and num_dims == 2:
+    values = np.swapaxes(values, 0, 1)
+    g0, g1 = grid[1], grid[0]
+    if g0.ndim > 1:
+      g0, g1 = g0.transpose(), g1.transpose()
     # end
+    grid[0], grid[1] = g0, g1
+    lower[0], lower[1] = lower[1], lower[0]
+    upper[0], upper[1] = upper[1], upper[0]
+    cells[0], cells[1] = cells[1], cells[0]
+    axes_labels[0], axes_labels[1] = axes_labels[1], axes_labels[0]
+  # end
 
   # Get the number of components and an indexer
   step = 2 if bool(streamline or quiver) else 1
@@ -251,9 +251,9 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
     # end
   # end
 
-    if transpose and num_dims == 1:
-      xlabel, ylabel = ylabel, xlabel
-    # end
+  if transpose and num_dims == 1:
+    xlabel, ylabel = ylabel, xlabel
+  # end
 
   # ---- Prepare Figure and Axes ----------------------------------------
   if bool(figsize):

--- a/src/postgkyl/output/plot.py
+++ b/src/postgkyl/output/plot.py
@@ -362,9 +362,9 @@ def plot(data: GData | Tuple[list, np.ndarray], args: list = (),
       nodal_grid = _get_nodal_grid(grid, cells)
       x = (nodal_grid[0] + xshift)*xscale
       y = (values[..., comp] + yshift)*yscale
-        if transpose:  # put the coordinate on the vertical axis
-          x, y = y, x
-        # end
+      if transpose:  # put the coordinate on the vertical axis
+        x, y = y, x
+      # end
       im = cax.plot(x, y, *args, color=color, label=label, markersize=markersize)
 
     elif num_dims == 2:


### PR DESCRIPTION
The transpose option was doing nothing in plot command. It nows swtiches the horizontal and vertical axis.

Examples
```
pgkyl gk-load-quantity --quantity distf --name rt_gk_tcv_iwl_csbc_1x2v_p1 --species elc --frame 10 --path /Users/ahoffman/gkeyll_main/gkeyll/rt_gk_tcv_iwl_1x2v_p1.o/wk/ interp select --z0 -3.1415 pl --transpose
```
in *main* returns:

<img width="621" height="469" alt="Screenshot 2026-07-13 at 3 20 39 PM" src="https://github.com/user-attachments/assets/11bc2570-7be9-45e7-813f-9544d9823f56" />

With this PR it returns

<img width="632" height="479" alt="Screenshot 2026-07-13 at 3 20 11 PM" src="https://github.com/user-attachments/assets/1b18b66b-db82-4a67-8a73-68455a17a2a7" />

Same for 1D plots:

```
pgkyl tests/test_data/rt_gk_tcv_iwl_1x2v_p1-elc_250.gkyl interp select --z0=2 --z2=0 pl --transpose 
```
*main*:
<img width="633" height="476" alt="Screenshot 2026-07-13 at 3 22 05 PM" src="https://github.com/user-attachments/assets/336387d2-7e76-4725-b17e-dfa7d89a8991" />

this branch:
<img width="636" height="472" alt="Screenshot 2026-07-13 at 3 22 30 PM" src="https://github.com/user-attachments/assets/8bf5148e-9b4d-4a74-b3dc-a525e61c0547" />
